### PR TITLE
Disable all fields and hide submit button for unapproved apps

### DIFF
--- a/art_show/templates/art_show_applications/art_show_form.html
+++ b/art_show/templates/art_show_applications/art_show_form.html
@@ -1,4 +1,4 @@
-{% set readonly = ' readonly ' if app.status != c.UNAPPROVED and not admin_area else '' %}
+{% set readonly = ' disabled ' if app.status != c.UNAPPROVED and not admin_area else '' %}
 {% set no_help_text = readonly != '' %}
 {% set max_tables = c.MAX_ART_TABLES if not admin_area else 30 %}
 {% set max_panels = c.MAX_ART_PANELS if not admin_area else 30 %}

--- a/art_show/templates/art_show_applications/edit.html
+++ b/art_show/templates/art_show_applications/edit.html
@@ -29,11 +29,13 @@
 
       {% include 'art_show_applications/art_show_form.html' %}
 
+      {% if app.status == c.UNAPPROVED %}
       <div class="form-group">
         <div class="col-sm-6 col-sm-offset-3">
           <button type="submit" class="btn btn-primary">Update Application</button>
         </div>
       </div>
+      {% endif %}
     </form>
   </div>
 </div>


### PR DESCRIPTION
Fixes https://github.com/MidwestFurryFandom/art_show/issues/14 by disabling fields instead of making them readonly. Since there's no point in the applicant submitting the form after it's been reviewed, we also hide the submit button.