### PR TITLE
Art show email sending behavior fixes

### DIFF
--- a/art_show/automated_emails.py
+++ b/art_show/automated_emails.py
@@ -28,7 +28,8 @@ ArtShowAppEmail('Your {EVENT_NAME} Art Show application has been declined', 'art
                 ident='art_show_declined')
 
 ArtShowAppEmail('Reminder to pay for your {EVENT_NAME} Art Show application', 'art_show/payment_reminder.txt',
-                lambda a: a.status == c.APPROVED and days_before(14, c.ART_SHOW_PAYMENT_DUE) and a.is_unpaid,
+                lambda a: a.status == c.APPROVED and a.is_unpaid,
+                when=days_before(14, c.ART_SHOW_PAYMENT_DUE),
                 needs_approval=False,
                 ident='art_show_payment_reminder')
 

--- a/art_show/automated_emails.py
+++ b/art_show/automated_emails.py
@@ -10,7 +10,7 @@ class ArtShowAppEmail(AutomatedEmail):
     def __init__(self, subject, template, filter, ident, **kwargs):
         AutomatedEmail.__init__(self, ArtShowApplication, subject, template,
                                 lambda app: True and filter(app),
-                                ident, sender=c.PANELS_EMAIL, **kwargs)
+                                ident, sender=c.ART_SHOW_EMAIL, **kwargs)
 
 ArtShowAppEmail('Your {EVENT_NAME} Art Show application has been approved', 'art_show/approved.html',
                 lambda a: a.status == c.APPROVED,


### PR DESCRIPTION
Art show emails now send from the correct address and the payment reminder sends at the correct time (or at least not right away).

Fixes #34 and #35 