### PR TITLE
Updated attendee-facing wording to table sections

### DIFF
--- a/art_show/templates/art_show_applications/art_show_form.html
+++ b/art_show/templates/art_show_applications/art_show_form.html
@@ -35,11 +35,11 @@
 </div>
 
 <div class="form-group">
-  <label for="tables" class="col-sm-3 control-label">Tables</label>
+  <label for="tables" class="col-sm-3 control-label">Table Sections</label>
   <div class="col-sm-6">
     {% if app.tables and app.tables > max_tables and not admin_area %}
-      An admin has granted you {{ app.tables }} tables. Please contact us via via <a href='mailto:{{ c.ART_SHOW_EMAIL }}'>{{ c.ART_SHOW_EMAIL }}</a>
-      if you wish to change the number of tables on your application.
+      An admin has granted you {{ app.tables }} table sections. Please contact us via via <a href='mailto:{{ c.ART_SHOW_EMAIL }}'>{{ c.ART_SHOW_EMAIL }}</a>
+      if you wish to change the number of table sections on your application.
     {% else %}
       <select class="form-control" name="tables"{{ readonly }}>
         {{ int_options(0, max_tables, app.tables) }}
@@ -49,7 +49,7 @@
     <div class="clearfix"></div>
     <p class="help-block col-sm-6 col-sm-offset-3">
       <i>You may contact us via <a href='mailto:{{ c.ART_SHOW_EMAIL }}'>{{ c.ART_SHOW_EMAIL }}</a> to request more
-        than {{ c.MAX_ART_TABLES }} tables.</i></p>
+        than {{ c.MAX_ART_TABLES }} table sections.</i></p>
     {% endif %}
   {% endif %}
 </div>

--- a/art_show/templates/emails/art_show/appchange_notification.html
+++ b/art_show/templates/emails/art_show/appchange_notification.html
@@ -11,7 +11,7 @@ the changes.
 <ul>
     {% if app.artist_name %}<li><strong>Artist Name</strong>: {{ app.artist_name }}</li>{% endif %}
     <li><strong>Panels</strong>: {{ app.panels }} panels (${{ app.panels_cost }}) </li>
-    <li><strong>Tables</strong>: {{ app.tables }} table spaces (${{ app.tables_cost }}) </li>
+    <li><strong>Table Sections</strong>: {{ app.tables }} table sections (${{ app.tables_cost }}) </li>
     <li><strong>Total Price</strong>: ${{ app.potential_cost }}</li>
     <li><strong>Description</strong>: {{ app.description }}</li>
     {% if app.special_needs %}<li><strong>Special Requests</strong>: {{ app.special_needs }}</li>{% endif %}

--- a/art_show/templates/emails/art_show/application.html
+++ b/art_show/templates/emails/art_show/application.html
@@ -16,7 +16,7 @@ may complete your registration
 <ul>
     {% if app.artist_name %}<li><strong>Artist Name</strong>: {{ app.artist_name }}</li>{% endif %}
     <li><strong>Panels</strong>: {{ app.panels }} panels (${{ app.panels_cost }}) </li>
-    <li><strong>Tables</strong>: {{ app.tables }} table spaces (${{ app.tables_cost }}) </li>
+    <li><strong>Table Sectionss</strong>: {{ app.tables }} table sections (${{ app.tables_cost }}) </li>
     <li><strong>Total Price</strong>: ${{ app.potential_cost }}</li>
     <li><strong>Description</strong>: {{ app.description }}</li>
     {% if app.special_needs %}<li><strong>Special Requests</strong>: {{ app.special_needs }}</li>{% endif %}

--- a/art_show/templates/emails/art_show/application.html
+++ b/art_show/templates/emails/art_show/application.html
@@ -16,7 +16,7 @@ may complete your registration
 <ul>
     {% if app.artist_name %}<li><strong>Artist Name</strong>: {{ app.artist_name }}</li>{% endif %}
     <li><strong>Panels</strong>: {{ app.panels }} panels (${{ app.panels_cost }}) </li>
-    <li><strong>Table Sectionss</strong>: {{ app.tables }} table sections (${{ app.tables_cost }}) </li>
+    <li><strong>Table Sections</strong>: {{ app.tables }} table sections (${{ app.tables_cost }}) </li>
     <li><strong>Total Price</strong>: ${{ app.potential_cost }}</li>
     <li><strong>Description</strong>: {{ app.description }}</li>
     {% if app.special_needs %}<li><strong>Special Requests</strong>: {{ app.special_needs }}</li>{% endif %}

--- a/art_show/templates/emails/art_show/approved.html
+++ b/art_show/templates/emails/art_show/approved.html
@@ -22,7 +22,7 @@ filled by another applicant.
 This registration includes:
 <ul>
     <li> {{ app.panels }} panels (${{ app.panels_cost }}) </li>
-    <li> {{ app.tables }} table spaces (${{ app.tables_cost }}) </li>
+    <li> {{ app.tables }} table sectionss (${{ app.tables_cost }}) </li>
 </ul>
 
 <br/>You can always review the {{ c.EVENT_NAME }} Art Show rules

--- a/art_show/templates/emails/art_show/approved.html
+++ b/art_show/templates/emails/art_show/approved.html
@@ -22,7 +22,7 @@ filled by another applicant.
 This registration includes:
 <ul>
     <li> {{ app.panels }} panels (${{ app.panels_cost }}) </li>
-    <li> {{ app.tables }} table sectionss (${{ app.tables_cost }}) </li>
+    <li> {{ app.tables }} table sections (${{ app.tables_cost }}) </li>
 </ul>
 
 <br/>You can always review the {{ c.EVENT_NAME }} Art Show rules


### PR DESCRIPTION
All attendee-facing references to "tables" now "Table sections" to better clarify that they are not getting a whole table. This was requested by art show staff.

fixes #37 