### PR TITLE
Add workflow for assigning and unassigning agents to art show apps

### DIFF
--- a/alembic/versions/1f862611ba04_make_sure_agents_are_attendees.py
+++ b/alembic/versions/1f862611ba04_make_sure_agents_are_attendees.py
@@ -1,0 +1,65 @@
+"""Make sure agents are attendees
+
+Revision ID: 1f862611ba04
+Revises: a18bda430e7f
+Create Date: 2018-05-19 14:37:54.148958
+
+"""
+
+
+# revision identifiers, used by Alembic.
+revision = '1f862611ba04'
+down_revision = 'a18bda430e7f'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+import residue
+
+
+try:
+    is_sqlite = op.get_context().dialect.name == 'sqlite'
+except Exception:
+    is_sqlite = False
+
+if is_sqlite:
+    op.get_context().connection.execute('PRAGMA foreign_keys=ON;')
+    utcnow_server_default = "(datetime('now', 'utc'))"
+else:
+    utcnow_server_default = "timezone('utc', current_timestamp)"
+
+def sqlite_column_reflect_listener(inspector, table, column_info):
+    """Adds parenthesis around SQLite datetime defaults for utcnow."""
+    if column_info['default'] == "datetime('now', 'utc')":
+        column_info['default'] = utcnow_server_default
+
+sqlite_reflect_kwargs = {
+    'listeners': [('column_reflect', sqlite_column_reflect_listener)]
+}
+
+# ===========================================================================
+# HOWTO: Handle alter statements in SQLite
+#
+# def upgrade():
+#     if is_sqlite:
+#         with op.batch_alter_table('table_name', reflect_kwargs=sqlite_reflect_kwargs) as batch_op:
+#             batch_op.alter_column('column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#     else:
+#         op.alter_column('table_name', 'column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#
+# ===========================================================================
+
+
+def upgrade():
+    op.add_column('art_show_application', sa.Column('agent_code', sa.Unicode(), server_default='', nullable=False))
+    op.add_column('art_show_application', sa.Column('agent_id', residue.UUID(), nullable=True))
+    op.create_foreign_key(op.f('fk_art_show_application_agent_id_attendee'), 'art_show_application', 'attendee', ['agent_id'], ['id'], ondelete='SET NULL')
+    op.drop_column('art_show_application', 'agent_name')
+
+
+def downgrade():
+    op.add_column('art_show_application', sa.Column('agent_name', sa.VARCHAR(), server_default=sa.text("''::character varying"), autoincrement=False, nullable=False))
+    op.drop_constraint(op.f('fk_art_show_application_agent_id_attendee'), 'art_show_application', type_='foreignkey')
+    op.drop_column('art_show_application', 'agent_id')
+    op.drop_column('art_show_application', 'agent_code')

--- a/art_show/configspec.ini
+++ b/art_show/configspec.ini
@@ -3,6 +3,7 @@ max_art_panels = integer(default=4)
 cost_per_table = integer(default=5)
 max_art_tables = integer(default=4)
 art_mailing_fee = integer(default=5)
+
 # Enter as a hundredths of a percent
 # For example, use 1000 for a sales tax of 10%.
 sales_tax = integer(default=1025)

--- a/art_show/site_sections/art_show_applications.py
+++ b/art_show/site_sections/art_show_applications.py
@@ -80,7 +80,7 @@ class Root:
                     app.email,
                     'Art Show Application Updated',
                     render('emails/art_show/appchange_notification.html',
-                           {'app': app}, encoding=None),
+                           {'app': app}), 'html'),
                     model=app.to_dict('id'))
                 raise HTTPRedirect('edit?id={}&message={}', app.id,
                                    'Your application has been updated')
@@ -110,7 +110,7 @@ class Root:
                 [app.agent.email, app.attendee.email],
                 '{} Art Show Agent Removed'.format(c.EVENT_NAME),
                 render('emails/art_show/agent_removed.html',
-                       {'app': app},
+                       {'app': app}), 'html',
                        encoding=None),
                 model=app.to_dict('id'))
             app.agent_id = None
@@ -120,7 +120,7 @@ class Root:
             app.attendee.email,
             'New Agent Code for the {} Art Show'.format(c.EVENT_NAME),
             render('emails/art_show/agent_code.html',
-                   {'app': app},
+                   {'app': app}), 'html',
                    encoding=None),
             'html',
             model=app.to_dict('id'))

--- a/art_show/site_sections/art_show_applications.py
+++ b/art_show/site_sections/art_show_applications.py
@@ -44,7 +44,7 @@ class Root:
                     app.email,
                     'Art Show Application Received',
                     render('emails/art_show/application.html',
-                           {'app': app}), 'html',
+                           {'app': app}, encoding=None), 'html',
                     model=app)
                 send_email(
                     c.ART_SHOW_EMAIL,
@@ -80,7 +80,7 @@ class Root:
                     app.email,
                     'Art Show Application Updated',
                     render('emails/art_show/appchange_notification.html',
-                           {'app': app}, 'html'),
+                           {'app': app}, encoding=None), 'html',
                     model=app.to_dict('id'))
                 raise HTTPRedirect('edit?id={}&message={}', app.id,
                                    'Your application has been updated')
@@ -110,8 +110,7 @@ class Root:
                 [app.agent.email, app.attendee.email],
                 '{} Art Show Agent Removed'.format(c.EVENT_NAME),
                 render('emails/art_show/agent_removed.html',
-                       {'app': app}, 'html',
-                       encoding=None),
+                       {'app': app}, encoding=None), 'html',
                 model=app.to_dict('id'))
             app.agent_id = None
 
@@ -120,8 +119,7 @@ class Root:
             app.attendee.email,
             'New Agent Code for the {} Art Show'.format(c.EVENT_NAME),
             render('emails/art_show/agent_code.html',
-                   {'app': app}, 'html',
-                   encoding=None),
+                   {'app': app}, encoding=None), 'html',
             model=app.to_dict('id'))
 
         raise HTTPRedirect('edit?id={}&message={}',

--- a/art_show/site_sections/art_show_applications.py
+++ b/art_show/site_sections/art_show_applications.py
@@ -80,7 +80,7 @@ class Root:
                     app.email,
                     'Art Show Application Updated',
                     render('emails/art_show/appchange_notification.html',
-                           {'app': app}), 'html'),
+                           {'app': app}, 'html'),
                     model=app.to_dict('id'))
                 raise HTTPRedirect('edit?id={}&message={}', app.id,
                                    'Your application has been updated')
@@ -110,7 +110,7 @@ class Root:
                 [app.agent.email, app.attendee.email],
                 '{} Art Show Agent Removed'.format(c.EVENT_NAME),
                 render('emails/art_show/agent_removed.html',
-                       {'app': app}), 'html',
+                       {'app': app}, 'html',
                        encoding=None),
                 model=app.to_dict('id'))
             app.agent_id = None
@@ -120,9 +120,8 @@ class Root:
             app.attendee.email,
             'New Agent Code for the {} Art Show'.format(c.EVENT_NAME),
             render('emails/art_show/agent_code.html',
-                   {'app': app}), 'html',
+                   {'app': app}, 'html',
                    encoding=None),
-            'html',
             model=app.to_dict('id'))
 
         raise HTTPRedirect('edit?id={}&message={}',
@@ -168,13 +167,15 @@ class Root:
                 c.ART_SHOW_EMAIL,
                 'Art Show Payment Received',
                 render('emails/art_show/payment_notification.txt',
-                       {'app': app}), model=app)
+                       {'app': app}), 
+                model=app)
             send_email.delay(
                 c.ART_SHOW_EMAIL,
                 app.email,
                 'Art Show Payment Received',
                 render('emails/art_show/payment_confirmation.txt',
-                       {'app': app}), model=app)
+                       {'app': app}), 
+                model=app)
             raise HTTPRedirect('edit?id={}&message={}',
                                attendee.art_show_application.id,
                                'Your payment has been accepted!')

--- a/art_show/templates/art_show_agent.html
+++ b/art_show/templates/art_show_agent.html
@@ -1,0 +1,22 @@
+<form method="post" id="new_agent_app" class="form-horizontal" action="../art_show_applications/new_agent_app">
+<div class="form-group" id="art-show-agent">
+  <label for="art_show_agent" class="col-sm-3 control-label optional-field">Art Show Agent</label>
+  <div class="col-sm-6">
+    <span class="form-control-static">
+    {% if attendee.art_agent_applications %}
+      You are currently an agent for the following artists:
+      <ul>{% for app in attendee.art_agent_applications %}
+        <li>{% if app.artist_name %}{{ app.artist_name }}{% else %}{{ app.attendee.full_name }}{% endif %}</li>
+      {% endfor %}</ul>
+    {% else %}
+      You are not an agent for any artists in the {{ c.EVENT_NAME }} Art Show.
+    {% endif %}
+    </span>
+      <div class="input-group">
+        <input type="hidden" name="id" form="new_agent_app" value="{{ attendee.id }}" />
+        <input type="text" class="form-control" name="agent_code" />
+        <span class="input-group-btn"><button type="submit" form="new_agent_app" class="btn btn-primary">Submit Agent Code</button></span>
+      </div>
+  </div>
+</div>
+</form>

--- a/art_show/templates/art_show_applications/art_show_form.html
+++ b/art_show/templates/art_show_applications/art_show_form.html
@@ -17,7 +17,7 @@
 <div class="form-group">
   <label for="delivery_method" class="col-sm-3 control-label">Art Delivery</label>
   <div class="col-sm-6">
-    <select name="delivery_method" class="form-control">
+    <select name="delivery_method" class="form-control"{{ readonly }}>
       {{ options(c.ART_SHOW_DELIVERY_OPTS,app.delivery_method) }}
     </select>
   </div>
@@ -26,6 +26,24 @@
   <p class="help-block col-sm-6 col-sm-offset-3">Mailing your art to the show incurs a fee of ${{ c.ART_MAILING_FEE }}.</p>
   {% endif %}
 </div>
+
+{% if app.agent_code %}
+<div class="form-group">
+  <label for="agent_code" class="col-sm-3 control-label">Agent</label>
+  <div class="col-sm-6">
+    {% if app.agent %}
+      {{ app.agent.full_name }} is currently assigned as your agent.
+    {% else %}
+    Your art show application does not have an agent assigned. Your agent code
+    is <strong>{{ app.agent_code }}</strong>. Your agent
+    can enter this code while preregistering for {{ c.EVENT_NAME }}, or after
+    registering by using their registration confirmation link.
+    {% endif %}
+    <input type="hidden" name="id" form="new_agent" value="{{ app.id }}" />
+    <br/><button type="submit" form="new_agent" class="btn btn-primary">Assign New Agent</button>
+  </div>
+</div>
+{% endif %}
 
 <div class="form-group">
   <label for="panels" class="col-sm-3 control-label">Panels</label>

--- a/art_show/templates/art_show_applications/edit.html
+++ b/art_show/templates/art_show_applications/edit.html
@@ -24,6 +24,7 @@
       Unfortunately, since your application has been {{ app.status_label|lower }}, you may no longer edit it. However,
       you may still view the details of your application below. <br/><br/>
       {% endif %}
+    <form method="post" id="new_agent" action="new_agent" role="form"></form>
     <form method="post" action="edit" class="form-horizontal" role="form">
       <input type="hidden" name="id" value="{{ app.id }}">
 

--- a/art_show/templates/emails/art_show/agent_code.html
+++ b/art_show/templates/emails/art_show/agent_code.html
@@ -1,0 +1,23 @@
+<html>
+<head></head>
+<body>
+
+We're emailing you because you requested a new agent code for your art
+application. Your new code is <strong>{{ app.agent_code }}</strong>. If you
+had an agent assigned to your art application, you and they will also receive
+an email confirming their unassignment.
+
+
+<br/><br/>To assign an agent to your art application, send them the above code.
+They must then add the code to their registration, either while signing up or
+afterwards by using the confirmation link they receive by email when they
+register. You can check your
+<a href="{{ c.URL_BASE }}/art_show_applications/edit?id={{ app.id }}">Art Show
+application </a> at any time to see your agent's status or assign a new agent.
+
+
+<br/> <br/> You can always review the {{ c.EVENT_NAME }} Art Show rules
+<a href="{{ c.ART_SHOW_RULES_URL }}" target="_blank">here</a>.
+
+</body>
+</html>

--- a/art_show/templates/emails/art_show/agent_removed.html
+++ b/art_show/templates/emails/art_show/agent_removed.html
@@ -1,0 +1,10 @@
+<html>
+<head></head>
+<body>
+
+We're emailing you because a new agent was requested for {% if app.artist_name %}{{ app.artist_name }}{% else %}{{ app.attendee.full_name }}{% endif %}'s art
+application. So {{ app.agent.full_name }} is no longer the agent for this art
+show application, and a new agent must be assigned instead.
+
+</body>
+</html>

--- a/art_show/templates/emails/art_show/appchange_notification.html
+++ b/art_show/templates/emails/art_show/appchange_notification.html
@@ -12,7 +12,7 @@ the changes.
     {% if app.artist_name %}<li><strong>Artist Name</strong>: {{ app.artist_name }}</li>{% endif %}
     <li><strong>Panels</strong>: {{ app.panels }} panels (${{ app.panels_cost }}) </li>
     <li><strong>Table Sections</strong>: {{ app.tables }} table sections (${{ app.tables_cost }}) </li>
-    <li><strong>Total Price</strong>: ${{ app.potential_cost }}</li>
+    <li><strong>Total Price</strong>: ${{ app.potential_cost }}{% if app.mailing_fee %} (including ${{ app.mailing_fee }} mailing fee){% endif %}</li>
     <li><strong>Description</strong>: {{ app.description }}</li>
     {% if app.special_needs %}<li><strong>Special Requests</strong>: {{ app.special_needs }}</li>{% endif %}
     {% if app.attendee.badge_status == c.NOT_ATTENDING %}<li>You will not be attending {{ c.EVENT_NAME }} and thus will

--- a/art_show/templates/emails/art_show/application.html
+++ b/art_show/templates/emails/art_show/application.html
@@ -13,11 +13,18 @@ may complete your registration
 <a href="{{ c.URL_BASE }}//preregistration/confirm?id={{ app.attendee_id }}">here</a>.
 {% endif %}
 
+{% if app.agent_code %}
+<br/><br/>In order to assign an agent to your art application, please send them
+this code: <strong>{{ app.agent_code }}</strong>. They must then add the code
+to their registration, either while signing up or afterwards by using the
+confirmation link they receive by email when they register.
+{% endif %}
+
 <ul>
     {% if app.artist_name %}<li><strong>Artist Name</strong>: {{ app.artist_name }}</li>{% endif %}
     <li><strong>Panels</strong>: {{ app.panels }} panels (${{ app.panels_cost }}) </li>
     <li><strong>Table Sections</strong>: {{ app.tables }} table sections (${{ app.tables_cost }}) </li>
-    <li><strong>Total Price</strong>: ${{ app.potential_cost }}</li>
+    <li><strong>Total Price</strong>: ${{ app.potential_cost }}{% if app.mailing_fee %} (including ${{ app.mailing_fee }} mailing fee){% endif %}</li>
     <li><strong>Description</strong>: {{ app.description }}</li>
     {% if app.special_needs %}<li><strong>Special Requests</strong>: {{ app.special_needs }}</li>{% endif %}
     {% if app.attendee.badge_status == c.NOT_ATTENDING %}<li>You will not be attending {{ c.EVENT_NAME }} and thus will

--- a/art_show/templates/emails/art_show/approved.html
+++ b/art_show/templates/emails/art_show/approved.html
@@ -29,6 +29,6 @@ This registration includes:
 <a href="{{ c.ART_SHOW_RULES_URL }}" target="_blank">here</a>.
 
 
-{{ c.ART_SHOW_SIGNATURE }}
+<br/><br/>{{ c.ART_SHOW_SIGNATURE }}
 </body>
 </html>

--- a/art_show/templates/emails/art_show/declined.txt
+++ b/art_show/templates/emails/art_show/declined.txt
@@ -1,4 +1,4 @@
-{{ attendee.first_name }},
+{{ app.attendee.first_name }},
 Thank you for applying to be in the art show at {{ c.EVENT_NAME }} this year. We regret to inform you that your application has been declined.
 {% if app.attendee.badge_status == c.NEW_STATUS %}
 Your registration is unaffected by the state of your application, so if you have not yet paid for your badge, we encourage you to do so. Your badge price will reflect the price at the time you applied for the art show. You may update and pay for your badge here: {{ c.URL_BASE }}/preregistration/confirm?id={{ app.attendee_id }}

--- a/art_show/templates/preregistration/confirm.html
+++ b/art_show/templates/preregistration/confirm.html
@@ -1,0 +1,7 @@
+{% extends "preregistration/confirm.html" %}
+{% block panel_top %}
+  {{ super() }}
+  {% if not attendee.is_new %}
+    {% include 'art_show_agent.html' %}
+  {% endif %}
+{% endblock %}

--- a/art_show/templates/regextra.html
+++ b/art_show/templates/regextra.html
@@ -1,1 +1,5 @@
 {% include 'art_show_link.html' %}
+
+{% if c.page_path != 'preregistration/form' %}
+{% include 'art_show_agent.html' %}
+{% endif %}


### PR DESCRIPTION
Art show applicants now receive a code to pass onto agents, who may then enter it during pre-reg or on their confirmation page. We overload promo codes to do the former, since it's actually super tricky to do anything to other models during pre-reg.