### PR TITLE
Fix all references to art show application, singular

### DIFF
--- a/art_show/models.py
+++ b/art_show/models.py
@@ -40,7 +40,7 @@ class SessionMixin:
             if attendee.badge_status in [c.INVALID_STATUS, c.WATCHED_STATUS]:
                 return None, \
                        'This badge is invalid. Please contact registration.'
-            elif attendee.art_show_application:
+            elif attendee.art_show_applications:
                 return None, \
                        'There is already an art show application ' \
                        'for that badge!'

--- a/art_show/site_sections/art_show_applications.py
+++ b/art_show/site_sections/art_show_applications.py
@@ -37,7 +37,7 @@ class Root:
                     app.status = c.WAITLISTED
                 session.add(attendee)
                 app.attendee = attendee
-                attendee.art_show_application = app
+
                 session.add(app)
                 send_email(
                     c.ART_SHOW_EMAIL,

--- a/art_show/templates/art_show_link.html
+++ b/art_show/templates/art_show_link.html
@@ -3,26 +3,30 @@
   <label for="art_show_link" class="col-sm-2 control-label optional-field">Art Show Application</label>
   <div class="col-sm-6">
     <p class="form-control-static">
-      {% if attendee.art_show_application and not admin_area %}
-        {% if attendee.art_show_application.status == c.UNAPPROVED %}
+      {% if attendee.art_show_applications and not admin_area %}
+        {% for app in attendee.art_show_applications %}
+          {% if app.status == c.UNAPPROVED %}
           Your art show application is pending review. You may still edit your application until it is reviewed.
-        {% elif attendee.art_show_application.status == c.WAITLISTED %}
+          {% elif app.status == c.WAITLISTED %}
           Your art show application is on our waitlist. You will receive an email if a spot opens up.
-        {% elif attendee.art_show_application.status == c.DECLINED %}
+          {% elif app.status == c.DECLINED %}
           Unfortunately, we were not able to accept your application.
-        {% else %}
-          Your application has been approved! {% if attendee.art_show_application.is_unpaid %}Please make sure to pay before the
+          {% else %}
+          Your application has been approved! {% if app.is_unpaid %}Please make sure to pay before the
           deadline of {{ c.ART_SHOW_PAYMENT_DUE|datetime_local }}.{% endif %}
-        {% endif %}
-        You may view your art show application
-        <a href="../art_show_applications/edit?id={{ attendee.art_show_application.id }}" target="_blank">here</a>.
+          {% endif %}
+          You may view your art show application
+          <a href="../art_show_applications/edit?id={{ app.id }}" target="_blank">here</a>.
+        {% endfor %}
       {% elif not admin_area %}
         You have not yet applied for the {{ c.EVENT_NAME }} art show! You may apply
         <a href="../art_show_applications/index?attendee_id={{ attendee.id }}" target="_blank">here</a>{% if c.AFTER_ART_SHOW_WAITLIST %} to be added to the waiting list{% endif %}.
         Art show applications close on {{ c.ART_SHOW_DEADLINE|datetime_local }}.
-      {% elif attendee.art_show_application and c.HAS_ART_SHOW_ACCESS %}
-        This attendee has an art show application with {{ attendee.art_show_application.status_label }} status.
-        <a href="../art_show_admin/form?id={{ attendee.art_show_application.id }}" target="_blank">View/Edit</a>
+      {% elif attendee.art_show_applications and c.HAS_ART_SHOW_ACCESS %}
+        {% for app in attendee.art_show_applications %}
+        This attendee has an art show application with {{ app.status_label }} status.
+          <a href="../art_show_admin/form?id={{ attendee.art_show_application.id }}" target="_blank">View/Edit</a>
+        {% endfor %}
       {% elif c.HAS_ART_SHOW_ACCESS %}
         This attendee does not have an art show application.
         <a href="../art_show_admin/form?attendee_id={{ attendee.id }}&new_app=true" target="_blank">Create one now</a>.


### PR DESCRIPTION
Our model structure changed and we missed a few spots. This was specifically causing a 500 error when checking confirmation numbers for new art apps.