### PR TITLE
Add art_show_reg_start

### DIFF
--- a/art_show/config.py
+++ b/art_show/config.py
@@ -1,6 +1,6 @@
 from sideboard.lib import parse_config
 
-from uber.config import c
+from uber.config import c, Config
 from uber.menu import MenuItem
 
 config = parse_config(__file__)
@@ -19,3 +19,10 @@ c.MENU.append_menu_item(MenuItem(name='Art Show', access=c.ART_SHOW, submenu=[
     MenuItem(name='Sales Charge Form',
              href='../art_show_admin/sales_charge_form'),
                                  ]))
+
+
+@Config.mixin
+class ExtraConfig:
+    @property
+    def ART_SHOW_OPEN(self):
+        return self.AFTER_ART_SHOW_REG_START and self.BEFORE_ART_SHOW_DEADLINE

--- a/art_show/configspec.ini
+++ b/art_show/configspec.ini
@@ -13,6 +13,7 @@ art_show_signature = string(default="")
 art_show_rules_url = string(default="")
 
 [dates]
+art_show_reg_start = string(default="2017-01-01")
 art_show_waitlist = string(default="2017-10-10")
 art_show_deadline = string(default="2017-10-10")
 art_show_payment_due = string(default="2017-10-10")

--- a/art_show/site_sections/art_show_applications.py
+++ b/art_show/site_sections/art_show_applications.py
@@ -14,6 +14,10 @@ class Root:
                                            ignore_csrf=True)
         attendee = None
 
+        if not c.ART_SHOW_OPEN:
+            return render('static_views/art_show_closed.html') if c.AFTER_ART_SHOW_DEADLINE \
+                else render('static_views/art_show_not_open.html')
+
         if cherrypy.request.method == 'GET' and params.get('attendee_id', ''):
             try:
                 attendee = session.attendee(id=params['attendee_id'])

--- a/art_show/templates/static_views/art_show_closed.html
+++ b/art_show/templates/static_views/art_show_closed.html
@@ -1,0 +1,5 @@
+<html><head></head><body style='text-align:center'>
+    Art show applications for {{ c.EVENT_NAME_AND_YEAR }} are now closed.<br/>
+    <br/>
+    Please <a href="{{ c.CONTACT_URL }}">contact us</a> if you have any questions.<br/>
+</body></html>

--- a/art_show/templates/static_views/art_show_not_open.html
+++ b/art_show/templates/static_views/art_show_not_open.html
@@ -1,0 +1,6 @@
+<html><head></head><body style='text-align:center'>
+    Art show applications for {{ c.EVENT_NAME_AND_YEAR }} are not yet open.
+    Please check back on {{ c.ART_SHOW_REG_START|datetime_local }}.<br/>
+    <br/>
+    Please <a href="{{ c.CONTACT_URL }}">contact us</a> if you have any questions.
+</body></html>


### PR DESCRIPTION
Fixes https://github.com/MidwestFurryFandom/art_show/issues/68. We check to see if art show registration is actually open before showing attendees the form.