### PR TITLE
Change art show app confirmation into an automated email

### DIFF
--- a/art_show/automated_emails.py
+++ b/art_show/automated_emails.py
@@ -25,28 +25,24 @@ ArtShowAppEmailFixture(
     '{EVENT_NAME} Art Show Application Confirmation',
     'art_show/application.html',
     lambda a: a.status == c.UNAPPROVED,
-    needs_approval=False,
     ident='art_show_confirm')
 
 ArtShowAppEmailFixture(
     'Your {EVENT_NAME} Art Show application has been approved',
     'art_show/approved.html',
     lambda a: a.status == c.APPROVED,
-    needs_approval=False,
     ident='art_show_approved')
 
 ArtShowAppEmailFixture(
     'Your {EVENT_NAME} Art Show application has been waitlisted',
     'art_show/waitlisted.txt',
     lambda a: a.status == c.WAITLISTED,
-    needs_approval=False,
     ident='art_show_waitlisted')
 
 ArtShowAppEmailFixture(
     'Your {EVENT_NAME} Art Show application has been declined',
     'art_show/declined.txt',
     lambda a: a.status == c.DECLINED,
-    needs_approval=False,
     ident='art_show_declined')
 
 ArtShowAppEmailFixture(
@@ -54,5 +50,4 @@ ArtShowAppEmailFixture(
     'art_show/payment_reminder.txt',
     lambda a: a.status == c.APPROVED and a.is_unpaid,
     when=days_before(14, c.ART_SHOW_PAYMENT_DUE),
-    needs_approval=False,
     ident='art_show_payment_reminder')

--- a/art_show/automated_emails.py
+++ b/art_show/automated_emails.py
@@ -22,6 +22,13 @@ class ArtShowAppEmailFixture(AutomatedEmailFixture):
 
 
 ArtShowAppEmailFixture(
+    '{EVENT_NAME} Art Show Application Confirmation',
+    'art_show/application.html',
+    lambda a: a.status == c.UNAPPROVED,
+    needs_approval=False,
+    ident='art_show_confirm')
+
+ArtShowAppEmailFixture(
     'Your {EVENT_NAME} Art Show application has been approved',
     'art_show/approved.html',
     lambda a: a.status == c.APPROVED,

--- a/art_show/models.py
+++ b/art_show/models.py
@@ -109,7 +109,6 @@ class ArtShowApplication(MagModel):
         return new_agent_code
 
 
-
     @property
     def total_cost(self):
         if self.status != c.APPROVED:

--- a/art_show/site_sections/art_show_applications.py
+++ b/art_show/site_sections/art_show_applications.py
@@ -45,13 +45,6 @@ class Root:
                 session.add(app)
                 send_email(
                     c.ART_SHOW_EMAIL,
-                    app.email,
-                    'Art Show Application Received',
-                    render('emails/art_show/application.html',
-                           {'app': app}, encoding=None), 'html',
-                    model=app)
-                send_email(
-                    c.ART_SHOW_EMAIL,
                     c.ART_SHOW_EMAIL,
                     'Art Show Application Received',
                     render('emails/art_show/reg_notification.txt',

--- a/art_show/templates/emails/art_show/application.html
+++ b/art_show/templates/emails/art_show/application.html
@@ -6,20 +6,6 @@ You have successfully submitted an application for the Art Show for {{ c.EVENT_N
 this coming {{ event_dates() }}. Below is a copy of your application. You may
 <a href="{{ c.URL_BASE }}/art_show_applications/edit?id={{ app.id }}">update it here</a>.
 
-<br/><br/>Should your application be approved, you will be required to pay for your space to complete your reservation.
-{% if app.attendee.badge_status == c.NEW_STATUS %}
-You MUST complete your {{ c.EVENT_NAME }} registration before you will be able to pay for your art show space. You
-may complete your registration
-<a href="{{ c.URL_BASE }}//preregistration/confirm?id={{ app.attendee_id }}">here</a>.
-{% endif %}
-
-{% if app.agent_code %}
-<br/><br/>In order to assign an agent to your art application, please send them
-this code: <strong>{{ app.agent_code }}</strong>. They must then add the code
-to their registration, either while signing up or afterwards by using the
-confirmation link they receive by email when they register.
-{% endif %}
-
 <ul>
     {% if app.artist_name %}<li><strong>Artist Name</strong>: {{ app.artist_name }}</li>{% endif %}
     <li><strong>Panels</strong>: {{ app.panels }} panels (${{ app.panels_cost }}) </li>
@@ -33,6 +19,21 @@ confirmation link they receive by email when they register.
     <li><strong>Website URL</strong>: {{ app.website }}</li>
 </ul>
 
+Should your application be approved, you will be required to pay for your space to complete your reservation.
+{% if app.attendee.badge_status == c.NEW_STATUS %}
+You MUST complete your {{ c.EVENT_NAME }} registration before you will be able to pay for your art show space. You
+may complete your registration
+<a href="{{ c.URL_BASE }}//preregistration/confirm?id={{ app.attendee_id }}">here</a>.
+{% endif %}
+
+{% if app.agent_code %}
+<br/><br/>In order to assign an agent to your art application, please send them
+this code: <strong>{{ app.agent_code }}</strong>. They must then add the code
+to their registration, either while signing up or afterwards by using the
+confirmation link they receive by email when they register.
+{% endif %}
+
+<br/><br/>
 {% if c.AFTER_ART_SHOW_WAITLIST %}
     Because our art show is currently full, your submission has been automatically placed on our waitlist.  We'll let
     you know if your application is later approved.

--- a/art_show/templates/emails/art_show/payment_notification.txt
+++ b/art_show/templates/emails/art_show/payment_notification.txt
@@ -1,2 +1,2 @@
-"{{ app.artist_name|default(app.attendee.full_name) }}" has just paid for their Art Show registration.
+{{ app.attendee.full_name }}{% if app.artist_name %} ("{{ app.artist_name }}"){% endif %} has just paid for their Art Show registration.
 {{ c.URL_BASE }}/art_show_admin/form?id={{ app.id }}

--- a/art_show/templates/emails/art_show/reg_notification.txt
+++ b/art_show/templates/emails/art_show/reg_notification.txt
@@ -1,2 +1,2 @@
-"{{ app.artist_name if app.artist_name else app.attendee.full_name }}" has just applied for the Art Show{% if c.AFTER_ART_SHOW_WAITLIST %} and was automatically waitlisted{% endif %}:
+{{ app.attendee.full_name }}{% if app.artist_name %} ("{{ app.artist_name }}"){% endif %} has just applied for the Art Show{% if c.AFTER_ART_SHOW_WAITLIST %} and was automatically waitlisted{% endif %}:
 {{ c.URL_BASE }}/art_show_admin/form?id={{ app.id }}

--- a/art_show/templates/emails/art_show/reg_notification.txt
+++ b/art_show/templates/emails/art_show/reg_notification.txt
@@ -1,2 +1,2 @@
-"{{ app.artist_name|default(app.attendee.full_name) }}" has just applied for the Art Show{% if c.AFTER_ART_SHOW_WAITLIST %} and was automatically waitlisted{% endif %}:
+"{{ app.artist_name if app.artist_name else app.attendee.full_name }}" has just applied for the Art Show{% if c.AFTER_ART_SHOW_WAITLIST %} and was automatically waitlisted{% endif %}:
 {{ c.URL_BASE }}/art_show_admin/form?id={{ app.id }}


### PR DESCRIPTION
We were sending this email with the send_email function, but that meant it was getting sent before we generated the agent code. Automated emails are better anyway. Fixes https://github.com/MidwestFurryFandom/art_show/issues/65.