### PR TITLE
Let admins reset artist's agent codes

### DIFF
--- a/art_show/site_sections/art_show_applications.py
+++ b/art_show/site_sections/art_show_applications.py
@@ -119,10 +119,11 @@ class Root:
 
         raise HTTPRedirect('edit?id={}&message={}', app.id, message)
 
-    def new_agent(self, session, id):
-        app = session.art_show_application(id)
+    def new_agent(self, session, **params):
+        app = session.art_show_application(params['id'])
         promo_code = session.promo_code(code=app.agent_code)
         message = 'Agent code updated'
+        page = "edit" if 'admin' not in params else "../art_show_admin/form"
 
         app.agent_code = app.new_agent_code()
         session.delete(promo_code)
@@ -145,8 +146,8 @@ class Root:
                    {'app': app}, encoding=None), 'html',
             model=app.to_dict('id'))
 
-        raise HTTPRedirect('edit?id={}&message={}',
-                           app.id, message)
+        raise HTTPRedirect('{}?id={}&message={}',
+                           page, app.id, message)
 
     def new_agent_app(self, session, id, **params):
         agent = session.attendee(id)

--- a/art_show/templates/art_show_admin/form.html
+++ b/art_show/templates/art_show_admin/form.html
@@ -15,6 +15,9 @@ app, c.PAGE_PATH,
     <a href="../registration/form?id={{ app.attendee.id }}">{{ app.attendee.full_name }}{% endif %}</a></h2>
 
   <div class="panel-body">
+    <form method="post" id="new_agent" action="../art_show_applications/new_agent" role="form">
+      <input type="hidden" name="admin" value="1" />
+    </form>
     <form method="post" action="form" class="form-horizontal" role="form">
       {% if new_app %}
       <input type="hidden" name="new_app" value="{{ new_app }}" />


### PR DESCRIPTION
The "Assign New Agent" button was appearing on the admin page, but it wasn't actually hooked up to anything! Fixes https://github.com/MidwestFurryFandom/art_show/issues/96.