### PR TITLE
Use from:c.ADMIN_EMAIL for emails to departments

### DIFF
--- a/art_show/site_sections/art_show_applications.py
+++ b/art_show/site_sections/art_show_applications.py
@@ -187,7 +187,7 @@ class Root:
                 attendee.amount_paid += charge.dollar_amount
             session.add(attendee)
             send_email.delay(
-                c.ART_SHOW_EMAIL,
+                c.ADMIN_EMAIL,
                 c.ART_SHOW_EMAIL,
                 'Art Show Payment Received',
                 render('emails/art_show/payment_notification.txt',


### PR DESCRIPTION
Not strictly necessary to fix https://github.com/MidwestFurryFandom/mff-rams-plugin/issues/76 but we might as well be consistent.