### PR TITLE
Redirect unpaid artists to art show payment page

### DIFF
--- a/art_show/configspec.ini
+++ b/art_show/configspec.ini
@@ -23,6 +23,7 @@ art_show_payment_due = string(default="2017-10-10")
 unapproved = string(default="Pending Approval")
 waitlisted = string(default="Waitlisted")
 approved   = string(default="Approved")
+paid = string(default="Paid")
 declined   = string(default="Declined")
 
 [[art_show_delivery]]

--- a/art_show/models.py
+++ b/art_show/models.py
@@ -148,7 +148,7 @@ class ArtShowApplication(MagModel):
         if self.delivery_method == c.BY_MAIL \
                 and not self.attendee.full_address:
             return "Mailing address required"
-        if self.attendee.badge_status == c.NEW_STATUS:
+        if self.attendee.placeholder and self.attendee.badge_status != c.NOT_ATTENDING:
             return "Missing registration info"
 
     @property
@@ -259,3 +259,12 @@ class Attendee:
                      or self.country not in ['United States', 'Canada']) \
                 and self.address1:
             return True
+
+    @property
+    def payment_page(self):
+        if self.art_show_applications:
+            for app in self.art_show_applications:
+                if app.total_cost:
+                    return '../art_show_applications/edit?id={}'.format(app.id)
+        else:
+            return 'attendee_donation_form?id={}'.format(self.id)

--- a/art_show/models.py
+++ b/art_show/models.py
@@ -252,7 +252,8 @@ class Attendee:
                 self.paid = c.HAS_PAID
 
             for app in self.art_show_applications:
-                app.status = c.PAID
+                if app.status == c.APPROVED:
+                    app.status = c.PAID
 
     @cost_property
     def art_show_app_cost(self):

--- a/art_show/site_sections/art_show_applications.py
+++ b/art_show/site_sections/art_show_applications.py
@@ -157,7 +157,8 @@ class Root:
             message = 'Please enter a state, province, or region.'
         if not attendee.country:
             message = 'Please enter a country.'
-        if not attendee.international and not c.AT_OR_POST_CON:
+        if not attendee.international and not c.AT_OR_POST_CON \
+                and attendee.country == 'United States':
             if _invalid_zip_code(attendee.zip_code):
                 message = 'Enter a valid zip code'
 
@@ -233,6 +234,8 @@ class Root:
                                    app.id, message)
             else:
                 attendee.amount_paid += charge.dollar_amount
+                if attendee.paid == c.NOT_PAID:
+                    attendee.paid = c.HAS_PAID
             session.add(attendee)
             send_email.delay(
                 c.ADMIN_EMAIL,

--- a/art_show/site_sections/art_show_applications.py
+++ b/art_show/site_sections/art_show_applications.py
@@ -234,6 +234,7 @@ class Root:
                                    app.id, message)
             else:
                 attendee.amount_paid += charge.dollar_amount
+                app.status = c.PAID
                 if attendee.paid == c.NOT_PAID:
                     attendee.paid = c.HAS_PAID
             session.add(attendee)

--- a/art_show/templates/art_show_admin/form.html
+++ b/art_show/templates/art_show_admin/form.html
@@ -64,7 +64,7 @@ app, c.PAGE_PATH,
         <label class="col-sm-3 control-label">Paid?</label>
         <div class="col-sm-6">
           <p class="form-control-static">
-            {% if app.status != c.APPROVED %}N/A{% else %}{{ app.is_unpaid|yesno('No,Yes') }}{% endif %}
+            {% if app.status == c.APPROVED %}No{% elif app.status == c.PAID %}Yes{% else %}N/A{% endif %}
             <a href="../art_show_applications/edit?id={{ app.id }}">(payment link)</a>
           </p>
         </div>

--- a/art_show/templates/art_show_admin/index.html
+++ b/art_show/templates/art_show_admin/index.html
@@ -50,7 +50,7 @@
         <td>{{ app.panels_ad }}</td>
         <td>{{ app.tables_ad }}</td>
         <td>${{ app.potential_cost }}</td>
-        <td>{% if app.status == c.APPROVED %}{{ app.is_unpaid|yesno('No,Yes') }}
+        <td>{% if app.status == c.APPROVED %}No{% elif app.status == c.PAID %}Yes
             {% else %}N/A ({{ app.incomplete_reason }}){% endif %}</td>
         <td>{{ app.admin_notes }}</td>
     </tr>

--- a/art_show/templates/art_show_applications/edit.html
+++ b/art_show/templates/art_show_applications/edit.html
@@ -6,8 +6,8 @@
 <div class="panel panel-default">
   <div class="panel-body">
     <h2>{{ c.EVENT_NAME }} Art Show Application</h2>
-      {% if app.status == c.APPROVED %}
-      Congratulations, your application has been approved!
+      {% if app.status in [c.APPROVED, c.PAID] %}
+      {% if app.status == c.APPROVED %}Congratulations, your application has been approved!{% endif %}
         {% if not app.incomplete_reason and app.is_unpaid %}
           In order to complete your application, please pay ${{ app.attendee.amount_unpaid }} using the button below.
           {% if app.attendee.badge_cost %}This total includes the cost of your badge, if you have not paid for it

--- a/art_show/templates/art_show_applications/edit.html
+++ b/art_show/templates/art_show_applications/edit.html
@@ -11,11 +11,11 @@
         {% if not app.incomplete_reason and app.is_unpaid %}
           In order to complete your application, please pay ${{ app.attendee.amount_unpaid }} using the button below.
           {% if app.attendee.badge_cost %}This total includes the cost of your badge, if you have not paid for it
-          already.{% endif %}<br/>
+          already.{% endif %}<br/><br/>
           <div style="text-align:center">
               {{ stripe_form('process_art_show_payment', charge) }}
           </div><br/><br/>
-        {% elif app.attendee.badge_status == c.NEW_STATUS %}
+        {% elif app.attendee.placeholder and app.attendee.badge_status != c.NOT_ATTENDING %}
           Before completing your application, please finish filling out your information
           <a href="../preregistration/confirm?id={{ app.attendee_id }}" target="_blank">here</a>. Afterwards, you will
           be able to pay for your application on this page.


### PR DESCRIPTION
Fixes https://github.com/MidwestFurryFandom/art_show/issues/101 by using the workflow we say we use.

After this PR is merged and deployed, we should run `/app/env/bin/python3 /app/sideboard/sep.py resave_all_attendees_and_groups` inside our web container. This will update all the apps to have the correct payment status as far as the system can tell.