### PR TITLE
Use pull-right class instead of col divs

### DIFF
--- a/art_show/templates/art_show_admin/index.html
+++ b/art_show/templates/art_show_admin/index.html
@@ -9,23 +9,20 @@
 </ol>
 
 <div class="panel panel-default">
-    <div class="panel-heading">
-        <h3 class="panel-title">Art Show Applications</h3>
+  <div class="panel-heading">
+    <h3 class="panel-title">Art Show Applications</h3>
+  </div>
+  <div class="panel-body">
+    <a class="btn btn-default" href="form?new_app=True">Add an application</a>
+    <div class="pull-right form-inline">
+      <div class="form-group">
+        <div class="control-label">Status</div> <div class="input-group" id="status_filter"></div>
+      </div>
+      <div class="form-group">
+        <div class="control-label">Paid</div> <span id="paid_filter"></span>
+      </div>
     </div>
-    <div class="panel-body">
-        <div class="row">
-            <div class="col-sm-3">
-                <a class="btn btn-default" href="form?new_app=True">Add an application</a></div>
-
-            <div class="col-sm-3 col-sm-offset-6 form-inline">
-                <div class="form-group">
-                <div class="control-label">Status</div> <div class="input-group" id="status_filter"></div>
-                </div>
-                <div class="form-group">
-                <div class="control-label">Paid</div> <span id="paid_filter"></span>
-                </div>
-            </div>
-        </div>
+  </div>
 <table class="table table-striped datatable">
 <thead><tr>
     <th>Name</th>


### PR DESCRIPTION
... Bootstrap.

Fixes https://github.com/MidwestFurryFandom/art_show/issues/116 by removing arbitrary column sizes. Any further shenanigans with the inputs stacking are up to Bootstrap.