### PR TITLE
Stop resetting for_sale and no_quick_sale when updating status

### DIFF
--- a/art_show/templates/art_pieces_form.html
+++ b/art_show/templates/art_pieces_form.html
@@ -171,6 +171,8 @@
             <input type="hidden" name="app_id" value="{{ app.id }}" />
             <input type="hidden" name="id" value="{{ piece.id }}" />
             <input type="hidden" name="return_to" value="{{ c.PAGE_PATH }}" />
+            {% if piece.for_sale %}<input type="hidden" name="for_sale" value=1 />{% endif %}
+            {% if piece.no_quick_sale %}<input type="hidden" name="no_quick_sale" value=1 />{% endif %}
             {{ csrf_token() }}
           <select name="status" class="form-control">
             {{ options(c.ART_PIECE_STATUS_OPTS, piece.status) }}


### PR DESCRIPTION
Fixes https://github.com/MidwestFurryFandom/art_show/issues/131, and also fixes the same problem for the no_quick_sale property, by including a hidden field in the status form if applicable.