### PR TITLE
Add missing {% endif %} tag to email template

### DIFF
--- a/art_show/templates/emails/art_show/approved.html
+++ b/art_show/templates/emails/art_show/approved.html
@@ -3,9 +3,8 @@
 <body>
 You have been approved to show in the Art Show for {{ c.EVENT_NAME }} this coming {{ event_dates() }}!
 
-{% if app.attendee.badge_status == c.NEW_STATUS %}
-<br/><br/>In order to complete your application, you must finish filling out your information
-<a href="{{ c.URL_BASE }}//preregistration/confirm?id={{ app.attendee_id }}">here</a>, and pay to {% if app.attendee.badge_status != c.NOT_ATTENDING %}register for the convention and {% endif %}be in the art show.
+<br/><br/>In order to complete your application, you must {% if app.attendee.badge_status == c.NEW_STATUS %}finish filling out your information
+<a href="{{ c.URL_BASE }}//preregistration/confirm?id={{ app.attendee_id }}">here</a>, and {% endif %}pay for {% if app.attendee.badge_status != c.NOT_ATTENDING %}your registration and {% endif %}art show application.
 Afterwards, you can enter your artwork <a href="{{ c.URL_BASE }}/art_show_applications/edit?id={{ app.id }}">on this page</a>.
 Payment is expected by {{ c.ART_SHOW_PAYMENT_DUE|datetime_local }} or your application may be removed and your space
 filled by another applicant.


### PR DESCRIPTION
The system would be unable to parse the template as-is, since Jinja2 requires you to end if-statements and throws a 500 error if you don't.