### PR TITLE
Fix date display in payment reminder email

### DIFF
--- a/art_show/templates/emails/art_show/payment_reminder.txt
+++ b/art_show/templates/emails/art_show/payment_reminder.txt
@@ -1,7 +1,7 @@
 {{ app.attendee.first_name }},
 
 Thanks again for applying to present in the Art Show for this year's {{ c.EVENT_NAME }}.  Our records indicate that your
-Art Show application is still unpaid, and if we do not receive payment by {{ c.ART_SHOW_PAYMENT_DUE }} then it will be
+Art Show application is still unpaid, and if we do not receive payment by {{ c.ART_SHOW_PAYMENT_DUE|datetime_local }} then it will be
 deleted.
 
 You can use the credit card button on your application's page to pay the ${{ app.attendee.amount_unpaid }} that you owe:


### PR DESCRIPTION
Missed a spot for |datetime_local.