### PR TITLE
Add sales page for quick sales and bid sales

### DIFF
--- a/alembic/versions/181ceea98b62_add_art_show_sales_tables.py
+++ b/alembic/versions/181ceea98b62_add_art_show_sales_tables.py
@@ -56,7 +56,7 @@ def upgrade():
     sa.Column('id', residue.UUID(), nullable=False),
     sa.Column('invoice_num', sa.Integer(), server_default='0', nullable=False),
     sa.Column('attendee_id', residue.UUID(), nullable=True),
-    sa.Column('open', sa.Boolean(), server_default='True', nullable=False),
+    sa.Column('closed', residue.UTCDateTime(), nullable=True),
     sa.ForeignKeyConstraint(['attendee_id'], ['attendee.id'], name=op.f('fk_art_show_receipt_attendee_id_attendee'), ondelete='SET NULL'),
     sa.PrimaryKeyConstraint('id', name=op.f('pk_art_show_receipt'))
     )

--- a/alembic/versions/676530c66ee7_add_buyers_for_pieces_and_payment_.py
+++ b/alembic/versions/676530c66ee7_add_buyers_for_pieces_and_payment_.py
@@ -1,0 +1,73 @@
+"""Add buyers for pieces and payment tracking
+
+Revision ID: 676530c66ee7
+Revises: 54227ab70c17
+Create Date: 2018-10-26 19:14:27.685763
+
+"""
+
+
+# revision identifiers, used by Alembic.
+revision = '676530c66ee7'
+down_revision = '54227ab70c17'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+import residue
+
+
+try:
+    is_sqlite = op.get_context().dialect.name == 'sqlite'
+except Exception:
+    is_sqlite = False
+
+if is_sqlite:
+    op.get_context().connection.execute('PRAGMA foreign_keys=ON;')
+    utcnow_server_default = "(datetime('now', 'utc'))"
+else:
+    utcnow_server_default = "timezone('utc', current_timestamp)"
+
+def sqlite_column_reflect_listener(inspector, table, column_info):
+    """Adds parenthesis around SQLite datetime defaults for utcnow."""
+    if column_info['default'] == "datetime('now', 'utc')":
+        column_info['default'] = utcnow_server_default
+
+sqlite_reflect_kwargs = {
+    'listeners': [('column_reflect', sqlite_column_reflect_listener)]
+}
+
+# ===========================================================================
+# HOWTO: Handle alter statements in SQLite
+#
+# def upgrade():
+#     if is_sqlite:
+#         with op.batch_alter_table('table_name', reflect_kwargs=sqlite_reflect_kwargs) as batch_op:
+#             batch_op.alter_column('column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#     else:
+#         op.alter_column('table_name', 'column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#
+# ===========================================================================
+
+
+def upgrade():
+    op.create_table('art_show_payment',
+    sa.Column('id', residue.UUID(), nullable=False),
+    sa.Column('attendee_id', residue.UUID(), nullable=True),
+    sa.Column('amount', sa.Integer(), server_default='0', nullable=False),
+    sa.Column('type', sa.Integer(), server_default='180350097', nullable=False),
+    sa.Column('when', residue.UTCDateTime(), nullable=False),
+    sa.ForeignKeyConstraint(['attendee_id'], ['attendee.id'], name=op.f('fk_art_show_payment_attendee_id_attendee'), ondelete='SET NULL'),
+    sa.PrimaryKeyConstraint('id', name=op.f('pk_art_show_payment'))
+    )
+    op.add_column('art_show_piece', sa.Column('buyer_id', residue.UUID(), nullable=True))
+    op.add_column('art_show_piece', sa.Column('winning_bid', sa.Integer(), server_default='0', nullable=True))
+    op.create_foreign_key(op.f('fk_art_show_piece_buyer_id_attendee'), 'art_show_piece', 'attendee', ['buyer_id'], ['id'], ondelete='SET NULL')
+
+
+def downgrade():
+    op.drop_constraint(op.f('fk_art_show_piece_buyer_id_attendee'), 'art_show_piece', type_='foreignkey')
+    op.drop_column('art_show_piece', 'winning_bid')
+    op.drop_column('art_show_piece', 'buyer_id')
+    op.drop_table('art_show_payment')

--- a/art_show/configspec.ini
+++ b/art_show/configspec.ini
@@ -54,3 +54,8 @@ sold = string(default="Sold")
 quick_sale = string(default="Quick Sale")
 return = string(default="Return to Artist")
 paid = string(default="Paid")
+
+[[art_show_payment]]
+stripe = string(default="Stripe")
+cash = string(default="Cash")
+refund = string(default="Refund")

--- a/art_show/models.py
+++ b/art_show/models.py
@@ -1,5 +1,6 @@
 import random
 import string
+import re
 
 from sqlalchemy import func
 
@@ -154,6 +155,10 @@ class ArtShowApplication(MagModel):
         return new_agent_code
 
     @property
+    def display_name(self):
+        return self.banner_name or self.artist_name or self.attendee.full_name
+
+    @property
     def incomplete_reason(self):
         if self.status not in [c.APPROVED, c.PAID]:
             return self.status_label
@@ -241,8 +246,12 @@ class ArtShowPiece(MagModel):
             self.piece_id = int(self.app.highest_piece_id) + 1
 
     @property
-    def barcode_data(self):
+    def artist_and_piece_id(self):
         return str(self.app.artist_id) + "-" + str(self.piece_id)
+
+    @property
+    def barcode_data(self):
+        return self.artist_and_piece_id
 
     @property
     def valid_quick_sale(self):
@@ -251,6 +260,11 @@ class ArtShowPiece(MagModel):
     @property
     def valid_for_sale(self):
         return self.for_sale and self.opening_bid
+
+    @property
+    def sale_price(self):
+        return self.winning_bid or self.quick_sale_price if self.valid_quick_sale else self.winning_bid
+
 
 @Session.model_mixin
 class Attendee:

--- a/art_show/site_sections/art_show_admin.py
+++ b/art_show/site_sections/art_show_admin.py
@@ -84,7 +84,7 @@ class Root:
         }
 
     def artist_check_in_out(self, session, checkout=False, message=''):
-        filters = [Attendee.checked_in != None] if c.AT_THE_CON else []
+        filters = []
         if checkout:
             filters.append(ArtShowApplication.checked_in != None)
         else:
@@ -261,7 +261,7 @@ class Root:
         return pdf.output(dest='S').encode('latin-1')
 
     def bidder_signup(self, session, message='', page=1, search_text='', order=''):
-        filters = [Attendee.checked_in != None] if c.AT_THE_CON else []
+        filters = []
         search_text = search_text.strip()
         if search_text:
             order = order or 'badge_printed_name'

--- a/art_show/site_sections/art_show_admin.py
+++ b/art_show/site_sections/art_show_admin.py
@@ -233,7 +233,7 @@ class Root:
             pdf.set_font("Arial", size=12)
             pdf.set_xy(81 + xplus, 54 + yplus)
             pdf.cell(160, 24,
-                     txt=(piece.app.banner_name or piece.app.artist_name or piece.app.attendee.full_name),
+                     txt=(piece.app.display_name),
                      ln=1, align="C")
             pdf.set_xy(81 + xplus, 80 + yplus)
             pdf.cell(160, 24, txt=piece.name, ln=1, align="C")
@@ -269,7 +269,7 @@ class Root:
                 attendees = session.query(Attendee).join(Attendee.art_show_bidder).filter(
                     ArtShowBidder.bidder_num.ilike('%{}%'.format(search_text[2:])))
             else:
-                # Sorting by bidder number requires a join, which would filter out anyone without a bidder num
+                # Sorting by bidder number requires a join, which would filter out anyone without a bidder number
                 order = 'badge_printed_name' if order == 'bidder_num' else order
                 try:
                     badge_num = int(search_text)
@@ -282,14 +282,13 @@ class Root:
         else:
             attendees = session.query(Attendee).join(Attendee.art_show_bidder)
 
-        count = attendees.count()
-
         if 'bidder_num' in str(order) or not order:
             attendees = attendees.join(Attendee.art_show_bidder).order_by(
                 ArtShowBidder.bidder_num.desc() if '-' in str(order) else ArtShowBidder.bidder_num)
         else:
             attendees = attendees.order(order)
 
+        count = attendees.count()
         page = int(page) or 1
 
         if not count:
@@ -331,18 +330,22 @@ class Root:
         else:
             session.commit()
 
-        return {'id': bidder.id,
-                'attendee_id': attendee.id,
-                'bidder_num': bidder.bidder_num,
-                'error': message,
-                'success': success}
+        return {
+            'id': bidder.id,
+            'attendee_id': attendee.id,
+            'bidder_num': bidder.bidder_num,
+            'error': message,
+            'success': success
+        }
 
     def print_bidder_form(self, session, id, **params):
         bidder = session.art_show_bidder(id)
         attendee = bidder.attendee
 
-        return {'model': attendee,
-                'type': 'bidder'}
+        return {
+            'model': attendee,
+            'type': 'bidder'
+        }
 
     @unrestricted
     def sales_charge_form(self, message='', amount=None, description='',

--- a/art_show/templates/art_pieces_form.html
+++ b/art_show/templates/art_pieces_form.html
@@ -188,7 +188,7 @@
       <tbody>
       {% for piece in app.art_show_pieces %}
       <tr class="piece-row" data-piece_id="{{ piece.id }}">
-        <td> {{ app.artist_id }}-{{ piece.piece_id }} </td>
+        <td> {{ piece.artist_and_piece_id }} </td>
         <td>
           {% if admin_area %}
           <form method="post" action="../art_show_applications/save_art_show_piece" target="upload_frame" role="form" class="form-horizontal">

--- a/art_show/templates/art_show_admin/bidder_signup.html
+++ b/art_show/templates/art_show_admin/bidder_signup.html
@@ -84,8 +84,6 @@
       </td>
       {% if attendee.art_show_bidder and attendee.art_show_bidder.signed_up %}
         <td><em>Signed-up {{ attendee.art_show_bidder.signed_up_local|datetime("%-I:%M%p")|lower }} {{ attendee.art_show_bidder.signed_up_local|datetime("%a") }}</em></td>
-      {% elif not attendee.checked_in and c.AT_THE_CON %}
-      <td>Attendee not checked in!</td>
       {% else %}
       <td id="cin_{{ attendee.id }}">
         <button class="btn btn-primary open_modal" data-attendee-id="{{ attendee.id }}">{% if attendee.art_show_bidder %}Complete {% endif %}Sign Up</button>

--- a/art_show/templates/art_show_admin/bidder_signup.html
+++ b/art_show/templates/art_show_admin/bidder_signup.html
@@ -77,7 +77,7 @@
       {% if c.NUMBERED_BADGES %}<td>{{ attendee.badge_num }}</td>{% endif %}
       <td>
         {% for app in attendee.art_show_applications %}
-        <a href="form?id={{ app.id }}">{{ app.banner_name or app.artist_name or attendee.full_name }}</a>
+        <a href="form?id={{ app.id }}">{{ app.display_name }}</a>
         {% else %}
         N/A
         {% endfor %}

--- a/art_show/templates/art_show_admin/form.html
+++ b/art_show/templates/art_show_admin/form.html
@@ -12,8 +12,7 @@ app, c.PAGE_PATH,
 
 <div class="panel panel-default">
 
-  <h2>Art Show Application Form{% if app.attendee %} for
-    <a href="../registration/form?id={{ app.attendee.id }}">{{ app.attendee.full_name }}{% endif %}</a></h2>
+  <h2>Art Show Application Form{% if app.attendee %} for {{ app.attendee|form_link }}{% endif %}</a></h2>
 
   <div class="panel-body">
     <form method="post" id="new_agent" action="../art_show_applications/new_agent" role="form">

--- a/art_show/templates/art_show_admin/ops.html
+++ b/art_show/templates/art_show_admin/ops.html
@@ -18,7 +18,7 @@
     <a class="btn btn-success" href="artist_check_in_out">Check In Artists</a>
     <a class="btn btn-info" href="bidder_signup">Add Bidders</a>
     <a class="btn btn-warning" href="artist_check_in_out?checkout=True">Check Out Artists</a>
-    <a class="btn btn-primary" href="#">Make Sale</a>
+    <a class="btn btn-primary" href="sales_search">Make Sale</a>
     <a class="btn btn-danger" href="#">Close Out</a>
   </div>
 </div>

--- a/art_show/templates/art_show_admin/pieces_bought.html
+++ b/art_show/templates/art_show_admin/pieces_bought.html
@@ -1,0 +1,171 @@
+{% extends "base.html" %}{% set admin_area=True %}
+{% block title %}Art Show Pieces Bought - {{ attendee.full_name }}{% endblock %}
+{% block content %}
+<h3>Art Show Purchases for {{ attendee|form_link }}</h3>
+<div class="panel panel-default">
+  <div class="panel-body">
+    <div class="row text-center">
+      <div class="col-sm-4">
+        <form role="form" method="post" action="pieces_bought" id="search_form">
+          <input type="hidden" name="id" value="{{ attendee.id }}" />
+          <div class="input-group">
+            <input class="focus form-control" id="search_bar" type="text" name="search_text" value="{{ search_text }}" />
+            <span class="input-group-btn">
+              <button class="btn btn-primary">Add Piece</button>
+          </span>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+  {% if must_choose %}
+  <div class="modal fade" id="choose_modal" role="dialog" tabindex="-1">
+    <div class="modal-dialog modal-lg" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+          <h4 class="modal-title">Choose Piece to Claim</h4>
+        </div>
+
+        <form role="form" method="get" class="form" action="pieces_bought">
+          <div class="modal-body">
+            <input type="hidden" name="id" value="{{ attendee.id }}" />
+            {% for piece in pieces %}
+            <button class="btn btn-default" name="search_text" value="{{ piece.artist_and_piece_id }}">
+              {{ piece.name }} by {{ piece.app.display_name }}
+            </button>
+            {% endfor %}
+            <br/><br/><button type="button" class="btn btn-danger" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">Nevermind</span></button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+  {% elif charge %}
+  <div class="modal fade" id="charge_modal" role="dialog" tabindex="-1">
+    <div class="modal-dialog modal-lg" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+          <h4 class="modal-title">Stripe Charge for ${{ '%0.2f' % (charge.amount / 100) }}</h4>
+        </div>
+
+          <div class="panel-body">
+            {{ stripe_form('purchases_charge', charge) }}
+            <br/><button type="button" class="btn btn-danger" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">Nevermind</span></button>
+          </div>
+
+      </div>
+    </div>
+  </div>
+  {% endif %}
+  <div class="table-responsive">
+    <table class="table table-striped">
+      <thead>
+      <tr>
+        <th>Unclaim Piece</th>
+        <th>ID</th>
+        <th>Status</th>
+        <th>Name</th>
+        <th>Media</th>
+        <th>Gallery</th>
+        <th>Type</th>
+        <th class="text-right">Price</th>
+      </tr>
+      </thead>
+      <tbody>
+      {% for piece in attendee.art_show_purchases %}
+      <tr class="piece-row" data-piece_id="{{ piece.id }}">
+        <td>
+          <form method="post" action="unclaim_piece">
+            {{ csrf_token() }}
+            <input type="hidden" name="id" value="{{ attendee.id }}" />
+            <input type="hidden" name="piece_id" value="{{ piece.id }}" />
+            <button type="submit" class="btn-xs btn-danger remove_piece" data-name="{{ piece.name }}">
+              Remove
+            </button>
+          </form>
+        </td>
+        <td> {{ piece.artist_and_piece_id }} </td>
+        <td>{{ piece.status_label }}</td>
+        <td> {{ piece.name }} </td>
+        <td> {{ piece.media }} </td>
+        <td> {{ piece.gallery_label }} </td>
+        <td> {{ piece.type_label }}
+          {% if piece.print_run_num and piece.type == c.PRINT %}({{ piece.print_run_num }} of {{ piece.print_run_total }}){% endif %}
+        </td>
+        <td class="text-right"> ${{ '%0.2f' % piece.sale_price }}
+        </td>
+      </tr>
+      {% endfor %}
+      {% if attendee.art_show_purchases %}
+      <tr><td colspan="8" class="text-right">Subtotal: ${{ '%0.2f' % attendee.art_show_purchases_sum }}</td></tr>
+      <tr><td colspan="8" class="text-right">Sales Tax ({{ c.SALES_TAX / 100 }}%): ${{ '%0.2f' % attendee.art_show_tax }}</td></tr>
+      <tr><td colspan="8" class="text-right">Total Cost: ${{ '%0.2f' % attendee.art_show_purchases_total }}</td></tr>
+      <tr><td colspan="8" class="text-right">Total Paid: ${{ '%0.2f' % (attendee.art_show_paid / 100) }}</td></tr>
+      <tr><td colspan="8"></td></tr>
+      {% if attendee.art_show_owed %}
+      <tr><td colspan="8" class="text-right">Owed: ${{ '%0.2f' % attendee.art_show_owed }}</td></tr>
+      <tr><td colspan="8" class="text-right">
+        <form role="form" method="post" class="form form-inline" action="record_payment">
+          <input type="hidden" name="id" value="{{ attendee.id }}" />
+          <input type="hidden" name="type" value="{{ c.CASH }}" />
+          <div class="input-group">
+          <span class="input-group-addon">$</span><input type="text" class="form-control" name="amount" placeholder="{{ '%0.2f' % attendee.art_show_owed }}" />
+          </div>
+          <button type="submit" class="btn btn-success">Record Cash Payment</button>
+        </form>
+      </td></tr>
+      <tr><td colspan="8" class="text-right">
+        <form role="form" method="post" class="form form-inline" action="pieces_bought">
+          <input type="hidden" name="id" value="{{ attendee.id }}" />
+          <div class="input-group">
+          <span class="input-group-addon">$</span><input type="text" class="form-control" name="amount" placeholder="{{ '%0.2f' % attendee.art_show_owed }}" />
+          </div>
+          <button type="submit" class="btn btn-success">Begin Card Payment</button>
+        </form>
+      </td></tr>
+      {% endif %}
+      <tr><td colspan="8" class="text-right">
+        <form role="form" method="post" class="form form-inline" action="record_payment">
+          <input type="hidden" name="id" value="{{ attendee.id }}" />
+          <input type="hidden" name="type" value="{{ c.REFUND }}" />
+          <div class="input-group">
+          <span class="input-group-addon">$</span><input type="text" class="form-control" name="amount" placeholder="{{ '%0.2f' % (attendee.art_show_paid / 100) }}" />
+          </div>
+          <button type="submit" class="btn btn-success">Record Refund</button>
+        </form>
+      </td></tr>
+      {% if not attendee.art_show_owed %}
+      <tr><td colspan="8" class="text-right"><button class="btn btn-primary" id="print_receipt">Print Receipt</button></td></tr>
+      {% endif %}
+      {% for payment in attendee.art_show_payments %}
+      <tr><td colspan="8" class="text-right">
+        {% if payment.type == c.REFUND %}
+        Refund of
+        {% else %}
+        {{ payment.type_label }} payment of
+        {% endif %}${{ '%0.2f' % (payment.amount / 100) }}
+        on {{ payment.when_local|datetime("%-I:%M%p")|lower }} {{ payment.when_local|datetime("%a") }}
+      </td></tr>
+      {% endfor %}
+      {% endif %}
+      </tbody>
+    </table>
+  </div>
+</div>
+{% if must_choose %}
+<script type="text/javascript">
+    $('.modal').modal('show');
+    $().ready(function() {
+        $("#choose_modal").on("hidden.bs.modal", function () {
+            window.location.assign('?id={{ attendee.id }}');
+        });
+    });
+</script>
+{% elif charge %}
+<script type="text/javascript">
+    $('.modal').modal('show');
+</script>
+{% endif %}
+{% endblock %}

--- a/art_show/templates/art_show_admin/pieces_bought.html
+++ b/art_show/templates/art_show_admin/pieces_bought.html
@@ -1,13 +1,13 @@
 {% extends "base.html" %}{% set admin_area=True %}
-{% block title %}Art Show Pieces Bought - {{ attendee.full_name }}{% endblock %}
+{% block title %}Art Show Pieces Bought - {{ receipt.attendee.full_name }}{% endblock %}
 {% block content %}
-<h3>Art Show Purchases for {{ attendee|form_link }}</h3>
+<h3>Art Show Purchases for {{ receipt.attendee|form_link }}</h3>
 <div class="panel panel-default">
   <div class="panel-body">
     <div class="row text-center">
       <div class="col-sm-4">
         <form role="form" method="post" action="pieces_bought" id="search_form">
-          <input type="hidden" name="id" value="{{ attendee.id }}" />
+          <input type="hidden" name="id" value="{{ receipt.attendee.id }}" />
           <div class="input-group">
             <input class="focus form-control" id="search_bar" type="text" name="search_text" value="{{ search_text }}" />
             <span class="input-group-btn">
@@ -29,7 +29,7 @@
 
         <form role="form" method="get" class="form" action="pieces_bought">
           <div class="modal-body">
-            <input type="hidden" name="id" value="{{ attendee.id }}" />
+            <input type="hidden" name="id" value="{{ receipt.attendee.id }}" />
             {% for piece in pieces %}
             <button class="btn btn-default" name="search_text" value="{{ piece.artist_and_piece_id }}">
               {{ piece.name }} by {{ piece.app.display_name }}
@@ -74,12 +74,12 @@
       </tr>
       </thead>
       <tbody>
-      {% for piece in attendee.art_show_purchases %}
+      {% for piece in receipt.pieces %}
       <tr class="piece-row" data-piece_id="{{ piece.id }}">
         <td>
           <form method="post" action="unclaim_piece">
             {{ csrf_token() }}
-            <input type="hidden" name="id" value="{{ attendee.id }}" />
+            <input type="hidden" name="id" value="{{ receipt.attendee.id }}" />
             <input type="hidden" name="piece_id" value="{{ piece.id }}" />
             <button type="submit" class="btn-xs btn-danger remove_piece" data-name="{{ piece.name }}">
               Remove
@@ -98,29 +98,29 @@
         </td>
       </tr>
       {% endfor %}
-      {% if attendee.art_show_purchases %}
-      <tr><td colspan="8" class="text-right">Subtotal: ${{ '%0.2f' % attendee.art_show_purchases_sum }}</td></tr>
-      <tr><td colspan="8" class="text-right">Sales Tax ({{ c.SALES_TAX / 100 }}%): ${{ '%0.2f' % attendee.art_show_tax }}</td></tr>
-      <tr><td colspan="8" class="text-right">Total Cost: ${{ '%0.2f' % attendee.art_show_purchases_total }}</td></tr>
-      <tr><td colspan="8" class="text-right">Total Paid: ${{ '%0.2f' % (attendee.art_show_paid / 100) }}</td></tr>
+      {% if receipt.pieces %}
+      <tr><td colspan="8" class="text-right">Subtotal: ${{ '%0.2f' % receipt.subtotal }}</td></tr>
+      <tr><td colspan="8" class="text-right">Sales Tax ({{ c.SALES_TAX / 100 }}%): ${{ '%0.2f' % receipt.tax }}</td></tr>
+      <tr><td colspan="8" class="text-right">Total Cost: ${{ '%0.2f' % receipt.total }}</td></tr>
+      <tr><td colspan="8" class="text-right">Total Paid: ${{ '%0.2f' % (receipt.paid / 100) }}</td></tr>
       <tr><td colspan="8"></td></tr>
-      {% if attendee.art_show_owed %}
-      <tr><td colspan="8" class="text-right">Owed: ${{ '%0.2f' % attendee.art_show_owed }}</td></tr>
+      {% if receipt.owed %}
+      <tr><td colspan="8" class="text-right">Owed: ${{ '%0.2f' % receipt.owed }}</td></tr>
       <tr><td colspan="8" class="text-right">
         <form role="form" method="post" class="form form-inline" action="record_payment">
-          <input type="hidden" name="id" value="{{ attendee.id }}" />
+          <input type="hidden" name="id" value="{{ receipt.attendee.id }}" />
           <input type="hidden" name="type" value="{{ c.CASH }}" />
           <div class="input-group">
-          <span class="input-group-addon">$</span><input type="text" class="form-control" name="amount" placeholder="{{ '%0.2f' % attendee.art_show_owed }}" />
+          <span class="input-group-addon">$</span><input type="text" class="form-control" name="amount" placeholder="{{ '%0.2f' % receipt.owed }}" />
           </div>
           <button type="submit" class="btn btn-success">Record Cash Payment</button>
         </form>
       </td></tr>
       <tr><td colspan="8" class="text-right">
         <form role="form" method="post" class="form form-inline" action="pieces_bought">
-          <input type="hidden" name="id" value="{{ attendee.id }}" />
+          <input type="hidden" name="id" value="{{ receipt.attendee.id }}" />
           <div class="input-group">
-          <span class="input-group-addon">$</span><input type="text" class="form-control" name="amount" placeholder="{{ '%0.2f' % attendee.art_show_owed }}" />
+          <span class="input-group-addon">$</span><input type="text" class="form-control" name="amount" placeholder="{{ '%0.2f' % receipt.owed }}" />
           </div>
           <button type="submit" class="btn btn-success">Begin Card Payment</button>
         </form>
@@ -128,18 +128,18 @@
       {% endif %}
       <tr><td colspan="8" class="text-right">
         <form role="form" method="post" class="form form-inline" action="record_payment">
-          <input type="hidden" name="id" value="{{ attendee.id }}" />
+          <input type="hidden" name="id" value="{{ receipt.attendee.id }}" />
           <input type="hidden" name="type" value="{{ c.REFUND }}" />
           <div class="input-group">
-          <span class="input-group-addon">$</span><input type="text" class="form-control" name="amount" placeholder="{{ '%0.2f' % (attendee.art_show_paid / 100) }}" />
+          <span class="input-group-addon">$</span><input type="text" class="form-control" name="amount" placeholder="{{ '%0.2f' % (receipt.paid / 100) }}" />
           </div>
           <button type="submit" class="btn btn-success">Record Refund</button>
         </form>
       </td></tr>
-      {% if not attendee.art_show_owed %}
-      <tr><td colspan="8" class="text-right"><button class="btn btn-primary" id="print_receipt">Print Receipt</button></td></tr>
+      {% if not receipt.owed %}
+      <tr><td colspan="8" class="text-right"><button class="btn btn-primary" id="print_receipt">Print & Close Out Receipt</button></td></tr>
       {% endif %}
-      {% for payment in attendee.art_show_payments %}
+      {% for payment in receipt.art_show_payments %}
       <tr><td colspan="8" class="text-right">
         {% if payment.type == c.REFUND %}
         Refund of
@@ -159,7 +159,7 @@
     $('.modal').modal('show');
     $().ready(function() {
         $("#choose_modal").on("hidden.bs.modal", function () {
-            window.location.assign('?id={{ attendee.id }}');
+            window.location.assign('?id={{ receipt.attendee.id }}');
         });
     });
 </script>

--- a/art_show/templates/art_show_admin/pieces_bought.html
+++ b/art_show/templates/art_show_admin/pieces_bought.html
@@ -2,12 +2,24 @@
 {% block title %}Art Show Pieces Bought - {{ receipt.attendee.full_name }}{% endblock %}
 {% block content %}
 <h3>Art Show Purchases for {{ receipt.attendee|form_link }}</h3>
+{% for receipt_iter in receipt.attendee.art_show_receipts %}
+{% if receipt_iter.id != receipt.id %}
+<a href="pieces_bought?id={{ receipt_iter.id }}">(Invoice #{{ receipt_iter.invoice_num }})</a>
+{% else %}
+Invoice #{{ receipt.invoice_num }}
+{% endif %}
+{% endfor %}
+{% if not receipt.attendee.art_show_receipt %}
+<a href="pieces_bought?id={{ receipt.attendee.id }}">[Start New Invoice]</a>
+{% endif %}
+{% set receipt_open = (receipt.id == receipt.attendee.art_show_receipt.id) %}
 <div class="panel panel-default">
+  {% if receipt_open %}
   <div class="panel-body">
     <div class="row text-center">
       <div class="col-sm-4">
         <form role="form" method="post" action="pieces_bought" id="search_form">
-          <input type="hidden" name="id" value="{{ receipt.attendee.id }}" />
+          <input type="hidden" name="id" value="{{ receipt.id }}" />
           <div class="input-group">
             <input class="focus form-control" id="search_bar" type="text" name="search_text" value="{{ search_text }}" />
             <span class="input-group-btn">
@@ -29,7 +41,7 @@
 
         <form role="form" method="get" class="form" action="pieces_bought">
           <div class="modal-body">
-            <input type="hidden" name="id" value="{{ receipt.attendee.id }}" />
+            <input type="hidden" name="id" value="{{ receipt.id }}" />
             {% for piece in pieces %}
             <button class="btn btn-default" name="search_text" value="{{ piece.artist_and_piece_id }}">
               {{ piece.name }} by {{ piece.app.display_name }}
@@ -50,20 +62,21 @@
           <h4 class="modal-title">Stripe Charge for ${{ '%0.2f' % (charge.amount / 100) }}</h4>
         </div>
 
-          <div class="panel-body">
-            {{ stripe_form('purchases_charge', charge) }}
-            <br/><button type="button" class="btn btn-danger" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">Nevermind</span></button>
-          </div>
+        <div class="panel-body">
+          {{ stripe_form('purchases_charge', charge) }}
+          <br/><button type="button" class="btn btn-danger" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">Nevermind</span></button>
+        </div>
 
       </div>
     </div>
   </div>
   {% endif %}
+  {% endif %}
   <div class="table-responsive">
     <table class="table table-striped">
       <thead>
       <tr>
-        <th>Unclaim Piece</th>
+        {% if receipt_open %}<th>Unclaim Piece</th>{% endif %}
         <th>ID</th>
         <th>Status</th>
         <th>Name</th>
@@ -76,16 +89,18 @@
       <tbody>
       {% for piece in receipt.pieces %}
       <tr class="piece-row" data-piece_id="{{ piece.id }}">
+        {% if receipt_open %}
         <td>
           <form method="post" action="unclaim_piece">
             {{ csrf_token() }}
-            <input type="hidden" name="id" value="{{ receipt.attendee.id }}" />
+            <input type="hidden" name="id" value="{{ receipt.id }}" />
             <input type="hidden" name="piece_id" value="{{ piece.id }}" />
             <button type="submit" class="btn-xs btn-danger remove_piece" data-name="{{ piece.name }}">
               Remove
             </button>
           </form>
         </td>
+        {% endif %}
         <td> {{ piece.artist_and_piece_id }} </td>
         <td>{{ piece.status_label }}</td>
         <td> {{ piece.name }} </td>
@@ -104,23 +119,23 @@
       <tr><td colspan="8" class="text-right">Total Cost: ${{ '%0.2f' % receipt.total }}</td></tr>
       <tr><td colspan="8" class="text-right">Total Paid: ${{ '%0.2f' % (receipt.paid / 100) }}</td></tr>
       <tr><td colspan="8"></td></tr>
-      {% if receipt.owed %}
+      {% if receipt.owed and receipt_open %}
       <tr><td colspan="8" class="text-right">Owed: ${{ '%0.2f' % receipt.owed }}</td></tr>
       <tr><td colspan="8" class="text-right">
         <form role="form" method="post" class="form form-inline" action="record_payment">
-          <input type="hidden" name="id" value="{{ receipt.attendee.id }}" />
+          <input type="hidden" name="id" value="{{ receipt.id }}" />
           <input type="hidden" name="type" value="{{ c.CASH }}" />
           <div class="input-group">
-          <span class="input-group-addon">$</span><input type="text" class="form-control" name="amount" placeholder="{{ '%0.2f' % receipt.owed }}" />
+            <span class="input-group-addon">$</span><input type="text" class="form-control" name="amount" placeholder="{{ '%0.2f' % receipt.owed }}" />
           </div>
           <button type="submit" class="btn btn-success">Record Cash Payment</button>
         </form>
       </td></tr>
       <tr><td colspan="8" class="text-right">
         <form role="form" method="post" class="form form-inline" action="pieces_bought">
-          <input type="hidden" name="id" value="{{ receipt.attendee.id }}" />
+          <input type="hidden" name="id" value="{{ receipt.id }}" />
           <div class="input-group">
-          <span class="input-group-addon">$</span><input type="text" class="form-control" name="amount" placeholder="{{ '%0.2f' % receipt.owed }}" />
+            <span class="input-group-addon">$</span><input type="text" class="form-control" name="amount" placeholder="{{ '%0.2f' % receipt.owed }}" />
           </div>
           <button type="submit" class="btn btn-success">Begin Card Payment</button>
         </form>
@@ -128,16 +143,16 @@
       {% endif %}
       <tr><td colspan="8" class="text-right">
         <form role="form" method="post" class="form form-inline" action="record_payment">
-          <input type="hidden" name="id" value="{{ receipt.attendee.id }}" />
+          <input type="hidden" name="id" value="{{ receipt.id }}" />
           <input type="hidden" name="type" value="{{ c.REFUND }}" />
           <div class="input-group">
-          <span class="input-group-addon">$</span><input type="text" class="form-control" name="amount" placeholder="{{ '%0.2f' % (receipt.paid / 100) }}" />
+            <span class="input-group-addon">$</span><input type="text" class="form-control" name="amount" placeholder="{{ '%0.2f' % (receipt.paid / 100) }}" />
           </div>
           <button type="submit" class="btn btn-success">Record Refund</button>
         </form>
       </td></tr>
       {% if not receipt.owed %}
-      <tr><td colspan="8" class="text-right"><button class="btn btn-primary" id="print_receipt">Print & Close Out Receipt</button></td></tr>
+      <tr><td colspan="8" class="text-right"><button class="btn btn-primary" id="print_receipt">Print{% if receipt_open %} & Close Out{% endif %} Receipt</button></td></tr>
       {% endif %}
       {% for payment in receipt.art_show_payments %}
       <tr><td colspan="8" class="text-right">
@@ -154,18 +169,27 @@
     </table>
   </div>
 </div>
-{% if must_choose %}
+<form role="form" method="post" id="print_form" action="print_receipt">
+  <input type="hidden" name="id" value="{{ receipt.id }}" />
+  {{ csrf_token() }}
+</form>
 <script type="text/javascript">
+    var printReceipt = function() {
+        window.open('', 'print_receipt_target', 'width=400,height=400,resizeable,scrollbars');
+        $('#print_form').attr('target', 'print_receipt_target').submit();
+    };
+
+    $('#print_receipt').click(printReceipt);
+
+    {% if must_choose %}
     $('.modal').modal('show');
     $().ready(function() {
         $("#choose_modal").on("hidden.bs.modal", function () {
-            window.location.assign('?id={{ receipt.attendee.id }}');
+            window.location.assign('?id={{ receipt.id }}');
         });
     });
-</script>
-{% elif charge %}
-<script type="text/javascript">
+    {% elif charge %}
     $('.modal').modal('show');
+    {% endif %}
 </script>
-{% endif %}
 {% endblock %}

--- a/art_show/templates/art_show_admin/print_receipt.html
+++ b/art_show/templates/art_show_admin/print_receipt.html
@@ -1,0 +1,49 @@
+{% extends "print_form.html" %}
+
+{% block printform %}
+<table class="table table-bordered" style="margin: 20px; width: calc(100% - 40px);">
+  <tr><td colspan="6" class="text-center"><strong>Midwest FurFest Art Show Receipt</strong></td></tr>
+  <tr>
+    <td colspan="3"><strong>Invoice #:</strong> {{ receipt.invoice_num }}</td>
+    <td colspan="3"><strong>Date and Time</strong> {{ receipt.closed_local|datetime("%m-%d-%Y - %H:%M") }}</td>
+  </tr>
+  <tr>
+    <td colspan="6"><strong>Sold To:</strong> {{ receipt.attendee.full_name }}</td>
+  </tr>
+  <tr><td colspan="6"></td></tr>
+  <tr>
+    <th><nobr>Piece ID</nobr></th>
+    <th>Piece Title</th>
+    <th>Type</th>
+    <th>Medium</th>
+    <th>Artist Name</th>
+    <th><nobr>Sale Price</nobr></th>
+  </tr>
+  {% for piece in receipt.pieces %}
+  <tr>
+    <td> {{ piece.artist_and_piece_id }} </td>
+    <td> {{ piece.name }} </td>
+    <td> {{ piece.type_label }}
+      {% if piece.print_run_num and piece.type == c.PRINT %}({{ piece.print_run_num }} of {{ piece.print_run_total }}){% endif %}
+    </td>
+    <td> {{ piece.media }} </td>
+    <td> {{ piece.app.display_name }} </td>
+    <td> ${{ '%0.2f' % piece.sale_price }}
+    </td>
+  </tr>
+  {% endfor %}
+  <tr><td colspan="6"></td></tr>
+  <tr><td colspan="4"></td><td><strong>TOTAL Pretax</strong></td><td>${{ '%0.2f' % receipt.subtotal }}</td></tr>
+  <tr><td colspan="4"></td><td><strong>Tax</strong></td><td>${{ '%0.2f' % receipt.tax }}</td></tr>
+  <tr><td colspan="4"></td><td><strong>Grand Total</strong></td><td>${{ '%0.2f' % receipt.total }}</td></tr>
+  <tr></tr>
+  {% for payment in receipt.stripe_payments %}
+  <tr>
+    <td colspan="4"></td><td><strong>Total Card {{ loop.index }}</strong></td><td>${{ '%0.2f' % (payment.amount / 100) }}</td>
+  </tr>
+  {% endfor %}
+  <tr><td colspan="4"></td><td><strong>Total Paid Credit</strong></td><td>${{ '%0.2f' % (receipt.stripe_total / 100) }}</td></tr>
+  <tr><td colspan="4"></td><td><strong>Total Paid Cash</strong></td><td>${{ '%0.2f' % (receipt.cash_total / 100) }}</td></tr>
+  <tr><td colspan="4"></td><td><strong>Amount Due:</strong></td><td>${{ '%0.2f' % (receipt.owed / 100) }}</td></tr>
+</table>
+{% endblock %}

--- a/art_show/templates/art_show_admin/sales_search.html
+++ b/art_show/templates/art_show_admin/sales_search.html
@@ -75,8 +75,8 @@
       </td>
       {% if c.PREASSIGNED_BADGE_TYPES %}<td>{{ attendee.badge_printed_name }}</td>{% endif %}
       {% if c.NUMBERED_BADGES %}<td>{{ attendee.badge_num }}</td>{% endif %}
-      <td>{{ '%0.2f' % (attendee.art_show_owed / 100) }}</td>
-      <td>{{ attendee.art_show_purchases|length }}</td>
+      <td>{{ '%0.2f' % (attendee.art_show_receipt.owed / 100) if attendee.art_show_receipt }}</td>
+      <td>{{ attendee.art_show_receipt.pieces|length }}</td>
       <td><a class="btn btn-primary" target="_sale" href="pieces_bought?id={{ attendee.id }}">Process Sale</a></td>
       {% endblock tablerows %}
     </tr>

--- a/art_show/templates/art_show_admin/sales_search.html
+++ b/art_show/templates/art_show_admin/sales_search.html
@@ -1,0 +1,108 @@
+{% extends "base.html" %}{% set admin_area=True %}
+{% block title %}Bidder Management{% endblock %}
+{% block content %}
+
+{% block adminheader %}
+<script>
+    $(function() {
+        $('#search_bar').select();
+    });
+</script>
+{% endblock adminheader %}
+{% block admin_controls %}
+<div class="row">
+  <div class="col-sm-6 col-md-4">
+    <h3>Art Show Sales</h3>
+    <form role="form" method="get" action="sales_search" id="search_form">
+      <div class="input-group">
+        <input class="focus form-control" id="search_bar" type="text" name="search_text" value="{{ search_text }}" />
+        <span class="input-group-btn">
+          <button class="btn btn-default" type="submit">
+              <span class="glyphicon glyphicon-search"></span>
+          </button>
+      </span>
+      </div>
+    </form>
+    {% if search_text %}<a href="sales_search">View all unpaid attendees with pieces</a>{% endif %}
+  </div>
+</div>
+{% endblock admin_controls %}
+{% block table %}
+<ul class="pagination{% if not page %} pagination-lg{% elif pages|length > 100 %} pagination-sm{% endif %}">
+  {% for pagenum in pages %}
+  {% if pagenum == page %}
+  <li class="page-item active">
+    <a class="page-link" href="#">{{ pagenum }}</a>
+  </li>
+  {% else %}
+  <li class="page-item">
+    <a class="page-link" href="sales_search?order={{ order }}&page={{ page }}&search_text={{ search_text|urlencode or '' }}">{{ pagenum }}</a>
+    {% endif %}
+  </li>
+  {% endfor %}
+</ul>
+<div class="panel panel-default">
+  {% if page %}
+  <table class="table table-striped" data-page-size="9999999">
+    <thead>
+    <tr>
+      {% block tableheadings %}
+      <th> <a href="sales_search?order={{ order.bidder_num }}&page={{ page }}&search_text={{ search_text|urlencode or '' }}">Bidder Number</a> </th>
+      <th> <a href="sales_search?order={{ order.full_name }}&page={{ page }}&search_text={{ search_text|urlencode or '' }}">Full Name</a> </th>
+      <th> <a href="sales_search?order={{ order.legal_name }}&page={{ page }}&search_text={{ search_text|urlencode or '' }}">Name on ID</a> </th>
+      {% if c.PREASSIGNED_BADGE_TYPES %}<th> <a href="sales_search?order={{ order.badge_printed_name }}&page={{ page }}&search_text={{ search_text|urlencode or '' }}">Badge Name</a> </th>{% endif %}
+      {% if c.NUMBERED_BADGES %}<th> <a href="sales_search?order={{ order.badge_num }}&page={{ page }}&search_text={{ search_text|urlencode or '' }}">Badge #</a> </th> {% endif %}
+      <th>Amount Owed</th>
+      <th># of Pieces</th>
+      <th></th>
+      {% endblock tableheadings %}
+    </tr>
+    </thead>
+    <tbody>
+    {% for attendee in attendees %}
+    <tr class="attendee-row" data-attendee_id="{{ attendee.id }}"{% if attendee.badge_status == c.INVALID_STATUS %} bgcolor="#FFE4E1"{% endif %}>
+      {% block tablerows scoped %}
+      <td id="group_{{ attendee.id }}">
+        {% if attendee.art_show_bidder %}
+        {{ attendee.art_show_bidder.bidder_num }}
+        {% endif %}
+      </td>
+      <td>
+        <a href="../registration/form?id={{ attendee.id }}">{{ attendee.full_name }}</a>
+      </td>
+      <td>
+        <a href="../registration/form?id={{ attendee.id }}">{{ attendee.legal_name }}</a>
+      </td>
+      {% if c.PREASSIGNED_BADGE_TYPES %}<td>{{ attendee.badge_printed_name }}</td>{% endif %}
+      {% if c.NUMBERED_BADGES %}<td>{{ attendee.badge_num }}</td>{% endif %}
+      <td>{{ '%0.2f' % (attendee.art_show_owed / 100) }}</td>
+      <td>{{ attendee.art_show_purchases|length }}</td>
+      <td><a class="btn btn-primary" target="_sale" href="pieces_bought?id={{ attendee.id }}">Process Sale</a></td>
+      {% endblock tablerows %}
+    </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <div class="lead text-center">
+    <em>Use the search box above to search for attendees by badge number or badge name.</em>
+  </div>
+  {% endif %}
+</div>
+{% if attendees|length > 15 %}
+<ul class="pagination{% if not page %} pagination-lg{% elif pages|length > 100 %} pagination-sm{% endif %}">
+  {% for pagenum in pages %}
+  {% if pagenum == page %}
+  <li class="page-item active">
+    <a class="page-link" href="#">{{ pagenum }}</a>
+  </li>
+  {% else %}
+  <li class="page-item">
+    <a class="page-link" href="sales_search?order={{ order }}&page={{ pagenum }}&search_text={{ search_text|urlencode or '' }}">{{ pagenum }}</a>
+    {% endif %}
+  </li>
+  {% endfor %}
+</ul>
+{% endif %}
+{% endblock table %}
+{% endblock content %}

--- a/art_show/templates/artist_checkin_macros.html
+++ b/art_show/templates/artist_checkin_macros.html
@@ -159,7 +159,7 @@
     <tbody>
     {% for piece in app.art_show_pieces|sort(attribute='piece_id')|sort(attribute='gallery_label') %}
     <tr class="piece-row" data-piece_id="{{ piece.piece_id }}">
-      <td> {{ app.artist_id }}-{{ piece.piece_id }} <input type="hidden" name="piece_ids" value="{{ piece.id }}" /> </td>
+      <td> {{ piece.artist_and_piece_id }} <input type="hidden" name="piece_ids" value="{{ piece.id }}" /> </td>
       {% if not printable %} <td>
         <select name="status{{ piece.id }}" class="form-control">
           {{ options(c.ART_PIECE_STATUS_OPTS, piece.status) }}

--- a/art_show/templates/emails/art_show/appchange_notification.html
+++ b/art_show/templates/emails/art_show/appchange_notification.html
@@ -10,7 +10,7 @@ the changes.
 
 <ul>
     {% if not app.incomplete_reason and not app.is_unpaid %}
-    <li><strong>Banner Name</strong>: {{ app.banner_name or app.artist_name or app.attendee.full_name }}</li>
+    <li><strong>Banner Name</strong>: {{ app.display_name }}</li>
     <li><strong>Name on Check</strong>: {{ app.check_payable or app.attendee.legal_name or app.attendee.full_name }}</li>
     {% if app.hotel_name %}<li><strong>Hotel Staying At</strong>: {{ app.hotel_name }}</li>{% endif %}
     {% if app.hotel_name %}<li><strong>Room Number</strong>: {{ app.hotel_room_num }}</li>{% endif %}

--- a/art_show/templates/emails/art_show/pieces_confirmation.html
+++ b/art_show/templates/emails/art_show/pieces_confirmation.html
@@ -23,7 +23,7 @@ You have updated your pieces for the Art Show.
         <tbody>
         {% for piece in app.art_show_pieces %}
         <tr class="piece-row" data-piece_id="{{ piece.id }}">
-            <td> {{ app.artist_id }}-{{ piece.piece_id }} </td>
+            <td> {{ piece.artist_and_piece_id }} </td>
             <td> {{ piece.status_label }} </td>
             <td> {{ piece.name }} </td>
             <td> {{ piece.media }} </td>

--- a/art_show/templates/print_form.html
+++ b/art_show/templates/print_form.html
@@ -17,11 +17,13 @@
 </head><body>
 <div class="panel-body">
   <div class="form-horizontal">
+    {% block printform %}
     {% if type == "bidder" %}
       {{ bidder_signup_macros.sign_up_form(model, True) }}
     {% elif type == "artist" %}
       {{ artist_checkin_macros.check_in_form(model, True) }}
     {% endif %}
+    {% endblock %}
   </div>
 </div>
 </body></html>


### PR DESCRIPTION
Fixes https://github.com/MidwestFurryFandom/art_show/issues/121. Fixes https://github.com/MidwestFurryFandom/art_show/issues/122. We use just one workflow for sales, which should hopefully be very efficient for both bid sales and quick sales.

This was a pretty big feature but it was all very interdependent -- I had to change the models to support multiple receipts midway through. 😰