### PR TITLE
Add editable cellphone field to bidder signup

### DIFF
--- a/art_show/site_sections/art_show_admin.py
+++ b/art_show/site_sections/art_show_admin.py
@@ -325,6 +325,8 @@ class Root:
             bidder = session.art_show_bidder(params)
         else:
             params.pop('id')
+            if 'cellphone' in params and params['cellphone']:
+                attendee.cellphone = params.pop('cellphone')
             bidder = ArtShowBidder()
             bidder.apply(params, restricted=False)
             attendee.art_show_bidder = bidder
@@ -333,7 +335,9 @@ class Root:
             bidder.signed_up = localized_now()
             success = 'Bidder signup complete'
 
-        message = check(bidder)
+        message = check(attendee)
+        if not message:
+            message = check(bidder)
         if message:
             session.rollback()
             return {'error': message}

--- a/art_show/templates/bidder_signup_macros.html
+++ b/art_show/templates/bidder_signup_macros.html
@@ -42,6 +42,18 @@
 {{ macros.name_form_group(attendee, label="Full Name", is_readonly=True) }}
 {{ macros.form_group(attendee, 'legal_name', label="Legal Name", is_readonly=True) }}
 {{ macros.address_form(attendee, is_readonly=True) }}
+{% if not attendee.cellphone and printable %}
+<div class="form-group">
+  <label class="col-sm-3 control-label optional-field">Phone</label>
+  <div class="col-sm-6">
+    <div class="form-control-static">
+      {{ attendee.cellphone }}
+    </div>
+  </div>
+</div>
+{% else %}
+{{ macros.form_group(attendee, 'cellphone', label="Phone", is_readonly=printable) }}
+{% endif %}
 
 {{ macros.form_group(attendee.art_show_bidder, 'hotel_name', label="Hotel", is_readonly=printable) }}
 {{ macros.form_group(attendee.art_show_bidder, 'hotel_room_num', label="Room Number", is_readonly=printable) }}


### PR DESCRIPTION
Fixes https://github.com/MidwestFurryFandom/art_show/issues/160. The field is editable, but if it's not collected we still print out a blank spot so it can be filled in with a pen.