### PR TITLE
Add Close-Out page for processing pieces after show close

### DIFF
--- a/art_show/site_sections/art_show_admin.py
+++ b/art_show/site_sections/art_show_admin.py
@@ -152,17 +152,17 @@ class Root:
         if piece.status == c.RETURN and piece.valid_quick_sale:
             message = 'This piece has a quick-sale price and so cannot yet be marked as Return to Artist.'
 
-        if piece.status != c.SOLD:
-            if 'bidder_id' in params:
-                message = 'You cannot assign a piece to a bidder\'s receipt without marking it as Sold.'
-            if not piece.winning_bid:
-                message = 'You cannot enter a winning bid for a piece without also marking it as Sold.'
-
         if 'bidder_id' not in params:
             if piece.status == c.SOLD:
                 message = 'You cannot mark a piece as Sold without a bidder. Please add a bidder number in step 1.'
             if piece.winning_bid:
                 message = 'You cannot enter a winning bid without a bidder. Please add a bidder number in step 1.'
+
+        if piece.status != c.SOLD:
+            if 'bidder_id' in params:
+                message = 'You cannot assign a piece to a bidder\'s receipt without marking it as Sold.'
+            if not piece.winning_bid:
+                message = 'You cannot enter a winning bid for a piece without also marking it as Sold.'
 
         if piece.status == c.SOLD and not piece.winning_bid:
             message = 'Please enter the winning bid for this piece.'

--- a/art_show/site_sections/art_show_admin.py
+++ b/art_show/site_sections/art_show_admin.py
@@ -94,6 +94,104 @@ class Root:
             'message': message,
         }
 
+    def close_out(self, session, message='', piece_code='', bidder_num='', **params):
+        found_piece, found_bidder, data_error = None, None, ''
+
+        if piece_code:
+            if len(piece_code.split('-')) != 2:
+                data_error = 'Please enter just one piece code.'
+            else:
+                artist_id, piece_id = piece_code.split('-')
+                try:
+                    piece_id = int(piece_id)
+                except Exception:
+                    data_error = 'Please use the format XXX-# for the piece code.'
+
+            if not data_error:
+                piece = session.query(ArtShowPiece).join(ArtShowPiece.app).filter(
+                    ArtShowApplication.artist_id.ilike('%{}%'.format(artist_id)),
+                    ArtShowPiece.piece_id == piece_id
+                )
+                if not piece.count():
+                    message = 'Could not find piece with code {}.'.format(piece_code)
+                elif piece.count() > 1:
+                    message = 'Multiple pieces matched the code you entered for some reason.'
+                else:
+                    found_piece = piece.one()
+
+                if bidder_num:
+                    bidder = session.query(ArtShowBidder).filter(ArtShowBidder.bidder_num.ilike(bidder_num))
+                    if not bidder.count():
+                        message = 'Could not find bidder with number {}.'.format(bidder_num)
+                    elif bidder.count() > 1:
+                        message = 'Multiple bidders matched the number you entered for some reason.'
+                    else:
+                        found_bidder = bidder.one().attendee
+            else:
+                message = data_error
+
+        return {
+            'message': message,
+            'piece_code': piece_code,
+            'bidder_num': bidder_num,
+            'piece': found_piece,
+            'bidder': found_bidder
+        }
+
+    def close_out_piece(self, session, message='', **params):
+        if 'id' not in params:
+            raise HTTPRedirect('close_out?piece_code={}&bidder_num={}&message={}',
+                               params['piece_code'], params['bidder_num'], 'Error: no piece ID submitted.')
+
+        piece = session.art_show_piece(params)
+        session.add(piece)
+
+        if piece.status == c.QUICK_SALE and not piece.valid_quick_sale:
+            message = 'This piece does not have a valid quick-sale price.'
+
+        if piece.status == c.RETURN and piece.valid_quick_sale:
+            message = 'This piece has a quick-sale price and so cannot yet be marked as Return to Artist.'
+
+        if piece.status != c.SOLD:
+            if 'bidder_id' in params:
+                message = 'You cannot assign a piece to a bidder\'s receipt without marking it as Sold.'
+            if not piece.winning_bid:
+                message = 'You cannot enter a winning bid for a piece without also marking it as Sold.'
+
+        if 'bidder_id' not in params:
+            if piece.status == c.SOLD:
+                message = 'You cannot mark a piece as Sold without a bidder. Please add a bidder number in step 1.'
+            if piece.winning_bid:
+                message = 'You cannot enter a winning bid without a bidder. Please add a bidder number in step 1.'
+
+        if piece.status == c.SOLD and not piece.winning_bid:
+            message = 'Please enter the winning bid for this piece.'
+
+        if piece.status == c.PAID:
+            message = 'Please process sales via the sales page.'
+
+        if 'bidder_id' in params:
+            attendee = session.attendee(params['bidder_id'])
+            if not attendee:
+                message = 'Attendee not found for some reason.'
+            elif not attendee.art_show_receipt:
+                receipt = ArtShowReceipt(attendee=attendee)
+                session.add(receipt)
+                session.commit()
+            else:
+                receipt = attendee.art_show_receipt
+
+            if not message:
+                piece.receipt = receipt
+
+        if message:
+            session.rollback()
+            raise HTTPRedirect('close_out?piece_code={}&bidder_num={}&message={}',
+                               params['piece_code'], params['bidder_num'], message)
+        else:
+            raise HTTPRedirect('close_out?message={}',
+                               'Close-out successful for piece {}'.format(piece.artist_and_piece_id))
+
     def artist_check_in_out(self, session, checkout=False, message=''):
         filters = []
         if checkout:

--- a/art_show/templates/art_show_admin/close_out.html
+++ b/art_show/templates/art_show_admin/close_out.html
@@ -1,0 +1,64 @@
+{% extends "base.html" %}{% set admin_area=True %}
+{% block title %}Close Out{% endblock %}
+{% block content %}
+
+{% block adminheader %}
+{% if bidder %}
+<script>
+    $(function() {
+        $.field('status').val({{ c.SOLD }})
+    });
+</script>
+{% endif %}
+{% endblock adminheader %}
+{% block admin_controls %}
+
+<h3>Close Out</h3>
+<div class="panel panel-default">
+  <div class="panel-body">
+    <strong>Step 1</strong>: Enter the artist code and piece number and, if applicable, the bidder number of the bidder who won the piece.
+    <form role="form" method="get" action="close_out" class="form-inline">
+      <div class="form-group">
+        <label class="control-label">Piece Code</label>
+        <input class="focus form-control" type="text" name="piece_code" value="{{ piece_code }}" placeholder="ART-1" />
+      </div>
+      <div class="form-group">
+        <label class="control-label">Bidder Number</label>
+        <input class="form-control" type="text" name="bidder_num" value="{{ bidder_num }}" placeholder="A-0001 (or leave blank)" />
+      </div>
+      <div class="form-group">
+        <button type="submit" class="btn btn-primary">Begin Close-Out</button>
+      </div>
+    </form>
+  </div>
+  {% if piece and (bidder or not bidder_num) %}
+  <div class="panel-body">
+    <strong>Step 2</strong>: Enter the status the piece should change to{% if bidder %} and the winning bid. <br/><strong>This piece will be added to {{ bidder|form_link }}'s receipt</strong>{% endif %}.
+    <form role="form" method="post" action="close_out_piece" class="form-inline">
+      <input type="hidden" name="id" value="{{ piece.id }}" />
+      {% if bidder %}<input type="hidden" name="bidder_id" value="{{ bidder.id }}" />{% endif %}
+      <input type="hidden" name="piece_code" value="{{ piece_code }}" />
+      <input type="hidden" name="bidder_num" value="{{ bidder_num }}" />
+      {{ csrf_token() }}
+      <div class="form-group">
+        <label class="control-label">Piece Status</label>
+        <select name="status" class="form-control">
+          {{ options(c.ART_PIECE_STATUS_OPTS, piece.status) }}
+        </select>
+      </div>
+      <div class="form-group">
+        <label class="control-label">High Bid</label>
+        <div class="input-group">
+          <span class="input-group-addon">$</span>
+          <input class="form-control" type="text" name="winning_bid" value="{{ piece.winning_bid if piece.winning_bid }}" />
+        </div>
+      </div>
+      <div class="form-group">
+        <button type="submit" class="btn btn-success">Close Out Piece {{ piece.artist_and_piece_id }}</button>
+      </div>
+    </form>
+  </div>
+  {% endif %}
+</div>
+{% endblock admin_controls %}
+{% endblock content %}

--- a/art_show/templates/art_show_admin/ops.html
+++ b/art_show/templates/art_show_admin/ops.html
@@ -19,7 +19,7 @@
     <a class="btn btn-info" href="bidder_signup">Add Bidders</a>
     <a class="btn btn-warning" href="artist_check_in_out?checkout=True">Check Out Artists</a>
     <a class="btn btn-primary" href="sales_search">Make Sale</a>
-    <a class="btn btn-danger" href="#">Close Out</a>
+    <a class="btn btn-danger" href="close_out">Close Out</a>
   </div>
 </div>
     {% endblock %}


### PR DESCRIPTION
Fixes https://github.com/MidwestFurryFandom/art_show/issues/143.

The system does a ton of checks to help reduce mistakes during close-out. Most of these messages should be self-explanatory for what triggers them -- if not, I added the (reason) after the message:
- 'This piece does not have a valid quick-sale price.' (if a piece is marked as Quick Sale when it cannot be quick-sold)
- 'This piece has a quick-sale price and so cannot yet be marked as Return to Artist.'
- 'You cannot mark a piece as Sold without a bidder. Please add a bidder number in step 1.'
- 'You cannot enter a winning bid without a bidder. Please add a bidder number in step 1.'
- 'You cannot assign a piece to a bidder's receipt without marking it as Sold.'
- 'You cannot enter a winning bid for a piece without also marking it as Sold.'
- 'Please enter the winning bid for this piece.' (if a piece is marked as Sold but no winning bid is entered)
- 'Please process sales via the sales page.' (if a piece is marked as Paid)

These messages are hierarchical, so the messages higher in the list will trigger before the messages underneath them. So if, say, someone tries to mark a piece as Sold without a bidder or a winning bid, the system tells them they need a bidder instead of telling them they need a winning bid. They're in the order they are to prevent frustrating sequences like: marking a piece as Sold, being told to enter the winning bid, _then_ having to go back to step 1 to add the bidder.

There's room for improvement on these errors but I didn't want to spend too much time on them when we can reasonably expect that staffers know what they're doing and the errors' main purpose is to catch slip-ups rather than train the staffer.