### PR TITLE
Encase 3of9 barcode data in asterisks like we're supposed to

### DIFF
--- a/art_show/models.py
+++ b/art_show/models.py
@@ -258,7 +258,7 @@ class ArtShowPiece(MagModel):
 
     @property
     def barcode_data(self):
-        return self.artist_and_piece_id
+        return "*" + self.artist_and_piece_id + "*"
 
     @property
     def valid_quick_sale(self):

--- a/art_show/site_sections/art_show_admin.py
+++ b/art_show/site_sections/art_show_admin.py
@@ -379,7 +379,7 @@ class Root:
             pdf.cell(132, 22, txt=piece.barcode_data, ln=1, align="C")
             pdf.set_font("Arial", size=8, style='B')
             pdf.set_xy(163 + xplus, 32 + yplus)
-            pdf.cell(132, 12, txt=piece.barcode_data, ln=1, align="C")
+            pdf.cell(132, 12, txt=piece.artist_and_piece_id, ln=1, align="C")
 
             # Artist, Title, Media
             pdf.set_font("Arial", size=12)


### PR DESCRIPTION
I have no idea why 3of9 barcodes need asterisks on either side of the data, but they do!