### PR TITLE
Force address form state to refresh on artist check-in modals

### DIFF
--- a/art_show/templates/art_pieces_form.html
+++ b/art_show/templates/art_pieces_form.html
@@ -5,6 +5,7 @@
     display: inline;
   }
 </style>
+<script type="text/javascript">{% include "region_opts.html" %}</script>
 
 {%- macro piece_modal(real_piece=None) -%}
 {% set piece = ArtShowPiece if not real_piece else real_piece %}

--- a/art_show/templates/art_show_admin/artist_check_in_out.html
+++ b/art_show/templates/art_show_admin/artist_check_in_out.html
@@ -2,7 +2,7 @@
 {% import 'artist_checkin_macros.html' as artist_checkin_macros with context %}
 {% block title %}Art Show Admin{% endblock %}
 {% block content %}
-
+<script type="text/javascript">{% include "region_opts.html" %}</script>
 <ol class="breadcrumb">
   <li><a href="../accounts/homepage">Home</a></li>
   <li>Art Show</li>
@@ -80,6 +80,11 @@
             var id = $(this).closest('.app-row').data('app_id');
             $('#app_modals').find('.modal').removeClass('print_form');
             $('#app_'+id).modal();
+
+            // We need to run regionChange again because the function is running before the modal is actually ready
+            $('#app_'+id).find('.address_suffixes').each(function() {
+                eval("regionChange" + $(this).val() + "()");
+            })
         };
 
         $(document).ready(function() {

--- a/art_show/templates/art_show_admin/ops.html
+++ b/art_show/templates/art_show_admin/ops.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}{% set admin_area=True %}
-{% import 'artist_checkin_macros.html' as artist_checkin_macros with context %}
 {% block title %}Art Show Admin{% endblock %}
 {% block content %}
 

--- a/art_show/templates/art_show_reports/index.html
+++ b/art_show/templates/art_show_reports/index.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}{% set admin_area=True %}
-{% import 'artist_checkin_macros.html' as artist_checkin_macros with context %}
 {% block title %}Art Show Admin{% endblock %}
 {% block content %}
 

--- a/art_show/templates/artist_checkin_macros.html
+++ b/art_show/templates/artist_checkin_macros.html
@@ -108,7 +108,6 @@
 {{ macros.name_form_group(app.attendee, label="Artist Full Name", is_readonly=printable) }}
 {{ macros.form_group(app.attendee, 'legal_name', label="Artist Legal Name", placeholder="Name exactly as it appears on Photo ID", is_readonly=printable) }}
 
-<script type="text/javascript">{% include "region_opts.html" %}</script>
 {% if app.attendee.badge_status != c.NOT_ATTENDING %}
 {{ macros.address_form(app.attendee, name_prefix="attendee_", label_prefix="Artist", is_readonly=printable) }}
 {% endif %}

--- a/art_show/templates/print_form.html
+++ b/art_show/templates/print_form.html
@@ -10,6 +10,7 @@
     }, 250);
   </script>
   {% endif %}
+  <script type="text/javascript">{% include "region_opts.html" %}</script>
   <link rel="stylesheet" href="{{ c.URL_BASE }}/static/deps/combined.min.css" />
   <style>
   @media print {


### PR DESCRIPTION
For unknown reasons, running regionChange() on page load was not actually changing the dropdown box inside the artist check-in model. This fixes that. We also do a bunch of clean-up to the address form to help output less HTML.

Requires https://github.com/MidwestFurryFandom/rams/pull/290.