### PR TITLE
Add ability for art show admins to change attendees on applications

### DIFF
--- a/art_show/configspec.ini
+++ b/art_show/configspec.ini
@@ -38,6 +38,7 @@ agent = string(default="I'm appointing an agent")
 
 [[art_show_access_level]]
 art_show = string(default="Art Show")
+art_show_admin = string(default="Art Show Admin")
 
 [[art_piece_type]]
 original = string(default="Original")

--- a/art_show/templates/art_show_admin/form.html
+++ b/art_show/templates/art_show_admin/form.html
@@ -27,7 +27,7 @@ app, c.PAGE_PATH,
 
       {{ csrf_token() }}
 
-      {% if new_app %}
+      {% if new_app or c.HAS_ART_SHOW_ADMIN_ACCESS %}
       <div class="form-group">
         <label for="attendee" class="col-sm-3 control-label">Attendee</label>
         <div class="col-sm-6">


### PR DESCRIPTION
This is a dangerous feature because there is no adjusting done for payment and we will almost certainly regret this.

Let's do it!

NOTE: admins must manually adjust the 'amount paid' when changing the attendee.

NOTE2: this uses a new level of access called Art Show Admin so we can restrict it to just Directors and ADs.