### PR TITLE
Add checkbox for mail-in artists verifying they will use a US address

### DIFF
--- a/alembic/versions/0a3de3158ae9_add_us_only_verification_for_mail_in_.py
+++ b/alembic/versions/0a3de3158ae9_add_us_only_verification_for_mail_in_.py
@@ -1,0 +1,59 @@
+"""Add US Only verification for mail-in artists
+
+Revision ID: 0a3de3158ae9
+Revises: fc49b3e7cc91
+Create Date: 2019-07-17 03:06:25.474811
+
+"""
+
+
+# revision identifiers, used by Alembic.
+revision = '0a3de3158ae9'
+down_revision = 'fc49b3e7cc91'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+
+try:
+    is_sqlite = op.get_context().dialect.name == 'sqlite'
+except Exception:
+    is_sqlite = False
+
+if is_sqlite:
+    op.get_context().connection.execute('PRAGMA foreign_keys=ON;')
+    utcnow_server_default = "(datetime('now', 'utc'))"
+else:
+    utcnow_server_default = "timezone('utc', current_timestamp)"
+
+def sqlite_column_reflect_listener(inspector, table, column_info):
+    """Adds parenthesis around SQLite datetime defaults for utcnow."""
+    if column_info['default'] == "datetime('now', 'utc')":
+        column_info['default'] = utcnow_server_default
+
+sqlite_reflect_kwargs = {
+    'listeners': [('column_reflect', sqlite_column_reflect_listener)]
+}
+
+# ===========================================================================
+# HOWTO: Handle alter statements in SQLite
+#
+# def upgrade():
+#     if is_sqlite:
+#         with op.batch_alter_table('table_name', reflect_kwargs=sqlite_reflect_kwargs) as batch_op:
+#             batch_op.alter_column('column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#     else:
+#         op.alter_column('table_name', 'column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#
+# ===========================================================================
+
+
+def upgrade():
+    op.add_column('art_show_application', sa.Column('us_only', sa.Boolean(), server_default='False', nullable=False))
+
+
+def downgrade():
+    op.drop_column('art_show_application', 'us_only')

--- a/art_show/configspec.ini
+++ b/art_show/configspec.ini
@@ -13,6 +13,10 @@ sales_tax = integer(default=1025)
 # This is printed on the artist invoice and in some reports
 commission_pct = integer(default=1000)
 
+# Requires applicants to check a box verifying their
+# mail-in address will be in the continental US
+by_mail_us_only = boolean(default=True)
+
 art_show_email = string(default="")
 art_show_signature = string(default="")
 art_show_rules_url = string(default="")

--- a/art_show/model_checks.py
+++ b/art_show/model_checks.py
@@ -32,6 +32,12 @@ def min_tables(app):
 
 
 @validation.ArtShowApplication
+def us_only(app):
+    if app.delivery_method == c.BY_MAIL and not app.us_only:
+        return 'Please confirm your address is within the continental US if you are mailing your art in.'
+
+
+@validation.ArtShowApplication
 def cant_ghost_art_show(app):
     if app.attendee and app.delivery_method == c.BRINGING_IN \
             and app.attendee.badge_status == c.NOT_ATTENDING:

--- a/art_show/models.py
+++ b/art_show/models.py
@@ -136,6 +136,7 @@ class ArtShowApplication(MagModel):
     special_needs = Column(UnicodeText)
     status = Column(Choice(c.ART_SHOW_STATUS_OPTS), default=c.UNAPPROVED)
     delivery_method = Column(Choice(c.ART_SHOW_DELIVERY_OPTS), default=c.BRINGING_IN)
+    us_only = Column(Boolean, default=False)
     admin_notes = Column(UnicodeText, admin_only=True)
     base_price = Column(Integer, default=0, admin_only=True)
     overridden_price = Column(Integer, nullable=True, admin_only=True)

--- a/art_show/site_sections/art_show_admin.py
+++ b/art_show/site_sections/art_show_admin.py
@@ -27,9 +27,9 @@ class Root:
 
     def form(self, session, new_app='', message='', **params):
         if new_app and 'attendee_id' in params:
-            app = session.art_show_application(params, ignore_csrf=True)
+            app = session.art_show_application(params, ignore_csrf=True, bools=['us_only'])
         else:
-            app = session.art_show_application(params)
+            app = session.art_show_application(params, bools=['us_only'])
         attendee = None
         app_paid = 0 if new_app else app.amount_paid
 
@@ -43,7 +43,7 @@ class Root:
         if cherrypy.request.method == 'POST':
             if new_app:
                 attendee, message = \
-                    session.attendee_from_art_show_app(**params)
+                    session.attendee_from_art_show_app( **params)
             else:
                 attendee = app.attendee
             message = message or check(app)

--- a/art_show/templates/art_show_applications/art_show_form.html
+++ b/art_show/templates/art_show_applications/art_show_form.html
@@ -65,7 +65,7 @@ placeholder=app.attendee.full_name, is_readonly=readonly) }}
   <label for="panels" class="col-sm-3 control-label{% if readonly %} optional-field{% endif %}">General Panels</label>
   <div class="col-sm-6">
     {% if app.panels and app.panels > max_panels and not admin_area %}
-      <div class="form-control-static">An admin has granted you {{ app.panels }} general panels. Please contact us via via <a href='mailto:{{ c.ART_SHOW_EMAIL }}'>{{ c.ART_SHOW_EMAIL }}</a>
+      <div class="form-control-static">An admin has granted you {{ app.panels }} general panels. Please contact us via via {{ c.ART_SHOW_EMAIL|email_only|email_to_link }}
       if you wish to change the number of panels on your application.</div>
     {% elif readonly %}
       <div class="form-control-static">{{ app.panels }}</div>
@@ -75,19 +75,13 @@ placeholder=app.attendee.full_name, is_readonly=readonly) }}
       </select>(${{ c.COST_PER_PANEL }} per panel)
     {% endif %}
     </div>
-    {% if not readonly and not admin_area and app.panels < max_panels %}
-    <div class="clearfix"></div>
-    <p class="help-block col-sm-6 col-sm-offset-3">
-      <i>You may contact us via <a href='mailto:{{ c.ART_SHOW_EMAIL }}'>{{ c.ART_SHOW_EMAIL }}</a> to request more
-        than {{ c.MAX_ART_PANELS }} panels.</i></p>
-    {% endif %}
 </div>
 
 <div class="form-group">
   <label for="tables" class="col-sm-3 control-label{% if readonly %} optional-field{% endif %}">General Table Sections</label>
   <div class="col-sm-6">
     {% if app.tables and app.tables > max_tables and not admin_area %}
-      <div class="form-control-static">An admin has granted you {{ app.tables }} general table sections. Please contact us via via <a href='mailto:{{ c.ART_SHOW_EMAIL }}'>{{ c.ART_SHOW_EMAIL }}</a>
+      <div class="form-control-static">An admin has granted you {{ app.tables }} general table sections. Please contact us via via {{ c.ART_SHOW_EMAIL|email_only|email_to_link }}
       if you wish to change the number of table sections on your application.</div>
     {% elif readonly %}
       <div class="form-control-static">{{ app.tables }}</div>
@@ -97,19 +91,13 @@ placeholder=app.attendee.full_name, is_readonly=readonly) }}
       </select>(${{ c.COST_PER_TABLE }} per table section)
     {% endif %}
     </div>
-    {% if not readonly and not admin_area and app.tables < max_tables %}
-    <div class="clearfix"></div>
-    <p class="help-block col-sm-6 col-sm-offset-3">
-      <i>You may contact us via <a href='mailto:{{ c.ART_SHOW_EMAIL }}'>{{ c.ART_SHOW_EMAIL }}</a> to request more
-        than {{ c.MAX_ART_TABLES }} table sections.</i></p>
-    {% endif %}
 </div>
 
 <div class="form-group">
   <label for="panels" class="col-sm-3 control-label{% if readonly %} optional-field{% endif %}">Mature Panels</label>
   <div class="col-sm-6">
     {% if app.panels_ad and app.panels_ad > max_panels and not admin_area %}
-      <div class="form-control-static">An admin has granted you {{ app.panels_ad }} mature panels. Please contact us via via <a href='mailto:{{ c.ART_SHOW_EMAIL }}'>{{ c.ART_SHOW_EMAIL }}</a>
+      <div class="form-control-static">An admin has granted you {{ app.panels_ad }} mature panels. Please contact us via via {{ c.ART_SHOW_EMAIL|email_only|email_to_link }}
       if you wish to change the number of panels on your application.</div>
     {% elif readonly %}
       <div class="form-control-static">{{ app.panels_ad }}</div>
@@ -119,19 +107,13 @@ placeholder=app.attendee.full_name, is_readonly=readonly) }}
       </select>{% if not no_help_text %}(${{ c.COST_PER_PANEL }} per panel){% endif %}
       {% endif %}
     </div>
-    {% if not readonly and not admin_area and app.panels_ad < max_panels %}
-    <div class="clearfix"></div>
-    <p class="help-block col-sm-6 col-sm-offset-3">
-      <i>You may contact us via <a href='mailto:{{ c.ART_SHOW_EMAIL }}'>{{ c.ART_SHOW_EMAIL }}</a> to request more
-        than {{ c.MAX_ART_PANELS }} panels.</i></p>
-    {% endif %}
 </div>
 
 <div class="form-group">
   <label for="tables" class="col-sm-3 control-label{% if readonly %} optional-field{% endif %}">Mature Table Sections</label>
   <div class="col-sm-6">
     {% if app.tables_ad and app.tables_ad > max_tables and not admin_area %}
-      <div class="form-control-static">An admin has granted you {{ app.tables_ad }} mature table sections. Please contact us via <a href='mailto:{{ c.ART_SHOW_EMAIL }}'>{{ c.ART_SHOW_EMAIL }}</a>
+      <div class="form-control-static">An admin has granted you {{ app.tables_ad }} mature table sections. Please contact us via {{ c.ART_SHOW_EMAIL|email_only|email_to_link }}
       if you wish to change the number of table sections on your application.</div>
     {% elif readonly %}
       <div class="form-control-static">{{ app.tables_ad }}</div>
@@ -141,14 +123,15 @@ placeholder=app.attendee.full_name, is_readonly=readonly) }}
       </select>{% if not no_help_text %}(${{ c.COST_PER_TABLE }} per table section){% endif %}
     {% endif %}
     </div>
-    {% if not readonly and not admin_area and app.tables_ad < max_tables %}
-    <div class="clearfix"></div>
-    <p class="help-block col-sm-6 col-sm-offset-3">
-      <i>You may contact us via <a href='mailto:{{ c.ART_SHOW_EMAIL }}'>{{ c.ART_SHOW_EMAIL }}</a> to request more
-        than {{ c.MAX_ART_TABLES }} table sections.</i></p>
-    {% endif %}
 </div>
 
+{% if not readonly and not admin_area and (app.panels < max_panels or app.tables < max_tables or app.tables_ad < max_tables or app.panels_ad < max_panels) %}
+<div class="help-block text-center">
+  You may contact us via {{ c.ART_SHOW_EMAIL|email_only|email_to_link }} to request more
+  than {{ c.MAX_ART_PANELS }} panels or{% if c.MAX_ART_PANELS != c.MAX_ART_TABLES %} {{ c.MAX_ART_TABLES }}{% endif %} table sections.<br/><br/>
+</div>
+{% endif %}
+
 {{ macros.form_group(app, 'description', type="textarea", label="Description", help="A short description of your artwork." if not admin_area else "", is_readonly=readonly, is_required=True) }}
-{{ macros.form_group(app, 'website', label="Website URL", is_readonly=readonly, is_required=True) }}
+{{ macros.form_group(app, 'website', label="Website URL", is_readonly=readonly, is_required=True, help="If you do not have a website showing your work, please enter 'N/A' and contact " + c.ART_SHOW_EMAIL|email_only|email_to_link + " after submitting your application.") }}
 {{ macros.form_group(app, 'special_needs', type="textarea", label="Special Requests", help="We cannot guarantee that we will accommodate all requests." if not admin_area else "", is_readonly=readonly) }}

--- a/art_show/templates/art_show_applications/art_show_form.html
+++ b/art_show/templates/art_show_applications/art_show_form.html
@@ -20,6 +20,20 @@ placeholder=app.attendee.full_name, is_readonly=readonly) }}
     </select>
     {% endif %}
   </div>
+  {% if c.BY_MAIL_US_ONLY %}
+  <div id="us_only_checkbox" class="col-sm-9 col-sm-offset-3">
+    {{ macros.checkbox(app, 'us_only', label='I verify that my mailing address will be in the continental US.') }}
+  </div>
+  <script type="text/javascript">
+      var showOrHideUSOnly = function() {
+          setVisible($('#us_only_checkbox'), $.field('delivery_method').val() == '{{ c.BY_MAIL }}');
+      };
+      $(function() {
+          showOrHideUSOnly();
+          $.field('delivery_method').on('change', showOrHideUSOnly);
+      });
+  </script>
+  {% endif %}
   {% if not readonly and not admin_area %}
   <div class="clearfix"></div>
   <p class="help-block col-sm-6 col-sm-offset-3">Mailing your art to the show incurs a fee of ${{ c.ART_MAILING_FEE }}.</p>


### PR DESCRIPTION
Artists are required to check a box saying they will provide an address in the continental US. Requires a DB migration.