### PR TITLE
Rename base migration

### DIFF
--- a/alembic/versions/b55cbf903320_initial_migration.py
+++ b/alembic/versions/b55cbf903320_initial_migration.py
@@ -1,6 +1,6 @@
 """Initial migration
 
-Revision ID: af64b33e950a
+Revision ID: b55cbf903320
 Revises: 735063d71b57
 Create Date: 2018-05-08 23:18:35.150928
 


### PR DESCRIPTION
Not entirely sure this does anything, but we noticed while sorting out our database migrations that some of our plugin migrations had a file name different from their actual revision ID. Renaming it in case it affects alembic's version table.