### PR TITLE
Standardize and improve printing of check-in form

### DIFF
--- a/art_show/templates/art_pieces_form.html
+++ b/art_show/templates/art_pieces_form.html
@@ -154,7 +154,11 @@
         </form>
       </div>
       {% endif %}
-      <button class="btn btn-success" onClick="printCheckInForm()">Print Check-In Form</button>
+      <form role="form" target="_blank" method="post" id="print_form" action="print_check_in_out_form">
+      <input type="hidden" name="id" value="{{ app.id }}" />
+      <button class="btn btn-success">Print Check-In Form</button>
+      {{ csrf_token() }}
+      </form>
     </div>
     {% if admin_area %}
     <div class="row text-center">
@@ -251,11 +255,6 @@
       {% endfor %}
       </tbody>
     </table>
-  </div>
-</div>
-<div id="print_form" style="display: none;">
-  <div class="form-horizontal">
-    {{ artist_checkin_macros.check_in_form(app, True) }}
   </div>
 </div>
 

--- a/art_show/templates/artist_checkin_macros.html
+++ b/art_show/templates/artist_checkin_macros.html
@@ -221,7 +221,7 @@
   {% if printable and not checkout %}
 <br/>
 <span class="text-center">
-<strong><p>I understand that I am giving Midwest Furfest the right to sell my art at the above prices.  I also understand that I will be charged a commission of 10% on all sales and that the convention will collect sales tax on my sales. I also have read and agree to the art show rules.</p>
+<strong><p class="pagebreak">I understand that I am giving Midwest Furfest the right to sell my art at the above prices.  I also understand that I will be charged a commission of 10% on all sales and that the convention will collect sales tax on my sales. I also have read and agree to the art show rules.</p>
 <p>MFF reserves the right to remove works for sale that, in our sole discretion, do not conform to our rules and policies. MFF will have no liability for any loss, including but not limited to lost revenue, resulting from the removal of works from the Furfest Art Show for violation of MFF's rules and/or policies.</p>
 <p>If I have chosen an Agent I understand that they have the rights to act as myself and make decisions on my behalf.</p>
 <p>I understand that all unsold art must be picked up between Noon and 5PM on Sunday.</p></strong><br/>

--- a/art_show/templates/print_form.html
+++ b/art_show/templates/print_form.html
@@ -5,13 +5,16 @@
   {% if not no_print %}
   <script type="text/javascript">
     window.self.onload = function() {
-        window.self.print();
-        window.self.close();
+      setTimeout(function () {
+        window.focus();
+        window.print();
+          window.close();
+      }, 250);
     };
   </script>
   {% endif %}
   <script type="text/javascript">{% include "region_opts.html" %}</script>
-  <link rel="stylesheet" href="{{ c.URL_BASE }}/static/deps/combined.min.css" />
+  <link rel="stylesheet" href="{{ c.URL_BASE }}/static/styles/bootstrap.min.css" />
   <style>
   @media print {
     .panel-body, .pull-left .pull-right { margin: 0 !important; padding: 0 !important; }


### PR DESCRIPTION
Fixes https://github.com/MidwestFurryFandom/art_show/issues/199, hopefully. I wasn't able to reliably reproduce the issue, but I believe it came down to the use of our full combined CSS in the print form rather than just the bootstrap CSS we needed.

We also now print the check-in form from the check-in box the same way we print it from the pieces screen -- for some reason they had different implementations.