### PR TITLE
Add status column to printed check-in/out forms

### DIFF
--- a/art_show/templates/artist_checkin_macros.html
+++ b/art_show/templates/artist_checkin_macros.html
@@ -1,6 +1,11 @@
 {% import 'macros.html' as macros with context %}
 
 {%- macro check_in_modal(app) -%}
+<style type="text/css">
+.dataTables_filter {
+display: none; 
+}
+</style>
 {% set printable = not admin_area if not printable else printable %}
 <div class="modal fade" id="app_{{ app.id }}" role="dialog" tabindex="-1">
   <div class="modal-dialog modal-lg" role="document">
@@ -184,11 +189,11 @@
 {% endif %}
 <br/>
 <div class="table-responsive">
-  <table class="table table-striped">
+  <table class="table table-striped{% if not printable %} datatable {% endif %}">
     <thead>
     <tr>
       <th>Piece ID</th>
-      {% if not printable %}<th>Piece Status</th>{% endif %}
+      <th>Piece Status</th>
       <th>Gallery</th>
       <th>Piece Name</th>
       <th>Minimum Bid</th>
@@ -199,16 +204,18 @@
     {% for piece in app.art_show_pieces|sort(attribute='piece_id')|sort(attribute='gallery_label') %}
     <tr class="piece-row" data-piece_id="{{ piece.piece_id }}">
       <td> {{ piece.artist_and_piece_id }} <input type="hidden" name="piece_ids{{ app.id }}" value="{{ piece.id }}" /> </td>
-      {% if not printable %} <td>
+      <td data-order="{{ piece.status_label }}">
+        {% if printable %}{{ piece.status_label }} {% else %}
         <select name="status{{ piece.id }}" class="form-control">
           {{ options(c.ART_PIECE_STATUS_OPTS, piece.status) }}
         </select>
-      </td>{% endif %}
-      <td> {% if printable %}{{ piece.gallery_label }}{% else %}{{ macros.buttongroup(piece, 'gallery', suffix=piece.id) }}{% endif %} </td>
-      <td> {% if printable %}{{ piece.name }}{% else %}<input type="text" class="form-control" name="name{{ piece.id }}" value="{{ piece.name }}" />{% endif %}</td>
-      <td> {% if printable %}{{ '$' ~ piece.opening_bid if piece.valid_for_sale else "N/A" }}
+        {% endif %}
+      </td>
+      <td data-order="{{ piece.gallery_label }}"> {% if printable %}{{ piece.gallery_label }}{% else %}{{ macros.buttongroup(piece, 'gallery', suffix=piece.id) }}{% endif %} </td>
+      <td data-order="{{ piece.name }}"> {% if printable %}{{ piece.name }}{% else %}<input type="text" class="form-control" name="name{{ piece.id }}" value="{{ piece.name }}" />{% endif %}</td>
+      <td data-order="{{ piece.opening_bid }}"> {% if printable %}{{ '$' ~ piece.opening_bid if piece.valid_for_sale else "N/A" }}
         {% else %}<input type="text" class="form-control" size="10" placeholder="N/A" name="opening_bid{{ piece.id }}" value="{{ piece.opening_bid if piece.valid_for_sale else '' }}" />{% endif %}</td>
-      <td> {% if printable %}{{ '$' ~ piece.quick_sale_price if piece.valid_quick_sale else "N/A" }}
+      <td data-order="{{ piece.quick_sale_price }}"> {% if printable %}{{ '$' ~ piece.quick_sale_price if piece.valid_quick_sale else "N/A" }}
         {% else %}<input type="text" class="form-control" size="10" placeholder="N/A" name="quick_sale_price{{ piece.id }}" value="{{ piece.quick_sale_price if piece.valid_quick_sale else '' }}" />{% endif %}
       </td>
     </tr>


### PR DESCRIPTION
Fixes https://github.com/MidwestFurryFandom/art_show/issues/245. Also fixes https://github.com/MidwestFurryFandom/art_show/issues/244 by adding sorting to the modal form.

I'm currently waiting on clarification for if different sorting on the _printed_ form is required or if it's just needed for the modal.