### PR TITLE
Fix 500 error when entering new pieces

### DIFF
--- a/art_show/site_sections/art_show_applications.py
+++ b/art_show/site_sections/art_show_applications.py
@@ -101,9 +101,9 @@ class Root:
         app = session.art_show_application(app_id)
 
         if cherrypy.request.method == 'POST':
+            piece.app = app
             message = check(piece)
             if not message:
-                piece.app = app
                 session.add(piece)
                 if not restricted and 'voice_auctioned' not in params:
                     piece.voice_auctioned = False


### PR DESCRIPTION
New pieces couldn't be entered at all because a model check was trying to access the piece's application before it had one. Now it's fixed!