### PR TITLE
Add app AND app_id to piece before model checks

### DIFF
--- a/art_show/site_sections/art_show_applications.py
+++ b/art_show/site_sections/art_show_applications.py
@@ -102,6 +102,7 @@ class Root:
 
         if cherrypy.request.method == 'POST':
             piece.app_id = app.id
+            piece.app = app
             message = check(piece)
             if not message:
                 session.add(piece)


### PR DESCRIPTION
I haven't the slightest idea how I didn't catch this during testing for the last PR; I must have forgotten to restart my local server after one of my changes. Not associating the piece with the app causes the general/mature check to fail -- not explicitly associating the app ID with the piece causes the duplicate name check to always pass. So we really do need both!