### PR TITLE
Update mail-in email date

### DIFF
--- a/art_show/automated_emails.py
+++ b/art_show/automated_emails.py
@@ -68,10 +68,9 @@ ArtShowAppEmailFixture(
     when=after(c.EVENT_TIMEZONE.localize(datetime(int(c.EVENT_YEAR), 11, 1))),
     ident='art_show_agent_reminder')
 
-
 ArtShowAppEmailFixture(
     '{EVENT_NAME} Art Show MAIL IN Instructions',
     'art_show/mailing_in.html',
     lambda a: a.status == c.PAID and a.delivery_method == c.BY_MAIL,
-    when=days_before(30, c.ART_SHOW_DEADLINE),
+    when=days_before(40, c.ART_SHOW_DEADLINE),
     ident='art_show_mail_in')


### PR DESCRIPTION
We actually want to send the mail-in instructions about a week before the dates it was set for, so we're updating its `when` property.