### PR TITLE
Stop resetting any approved application to approved/paid

### DIFF
--- a/art_show/site_sections/art_show_admin.py
+++ b/art_show/site_sections/art_show_admin.py
@@ -59,7 +59,7 @@ class Root:
                     session.add(attendee)
                     app.attendee = attendee
 
-                if 'mark_paid' in params:
+                if 'mark_paid' in params and app.status in [c.APPROVED, c.PAID]:
                     app.status = c.APPROVED if int(params['mark_paid']) == 0 else c.PAID
                 session.add(app)
                 if params.get('save') == 'save_return_to_search':


### PR DESCRIPTION
Fixes https://github.com/MidwestFurryFandom/art_show/issues/276. We use a payment dropdown box on the app form, but the logic that kept it synchronized with the app status was accidentally forcing an approved application to ALWAYS be either approved or paid, even if you selected a different status.