### PR TITLE
Label general/mature grids correctly on location assignments page

### DIFF
--- a/art_show/templates/art_show_admin/assign_locations.html
+++ b/art_show/templates/art_show_admin/assign_locations.html
@@ -12,8 +12,8 @@
     <thead><tr>
         <th>Artist Name</th>
         <th>Real Name</th>
-        <th>Mature Grids</th>
         <th>General Grids</th>
+        <th>Mature Grids</th>
         <th>General Tables</th>
         <th>Mature Tables</th>
         <th>Location</th>


### PR DESCRIPTION
Trish showed me this at-con and in the middle of writing up an issue for it I realized it was easier to just fix it -- the general/mature grid column labels were swapped.