### PR TITLE
Split check-out printing into two buttons

### DIFF
--- a/art_show/templates/art_show_admin/artist_check_in_out.html
+++ b/art_show/templates/art_show_admin/artist_check_in_out.html
@@ -140,14 +140,16 @@
                             if (!response['error']) {
                                 var $modals = $('#app_modals').find('.modal');
 
-                                if (print) {
+                                if (print || print_invoice) {
+                                  $('.print_id').val(response['id']);
+                                  if (print) {
                                     window.open('', 'print_form_target', 'width=400,height=400,resizeable,scrollbars');
-                                    $('.print_id').val(response['id']);
                                     $('#print_form').attr('target', 'print_form_target').submit();
-                                    if (print_invoice) {
-                                        window.open('', 'print_invoice_target', 'width=400,height=400,resizeable,scrollbars');
-                                        $('#print_invoice').attr('target', 'print_invoice_target').submit();
-                                    }
+                                  }
+                                  if (print_invoice) {
+                                      window.open('', 'print_invoice_target', 'width=400,height=400,resizeable,scrollbars');
+                                      $('#print_invoice').attr('target', 'print_invoice_target').submit();
+                                  }
                                 } else {
                                     $modals.modal('hide');
                                     location.href = '?{% if checkout %}checkout=True&{% endif %}message=' + response['success'];

--- a/art_show/templates/artist_checkin_macros.html
+++ b/art_show/templates/artist_checkin_macros.html
@@ -22,9 +22,14 @@ display: none;
         </div>
         <div class="modal-footer">
           {% set print_invoice = checkout and app.total_sales %}
-          <button type="submit" class="btn btn-primary save_app print{{ ' print_invoice' if print_invoice }}">
-            Save & Print Form{{ ' + Invoice' if print_invoice }}
+          <button type="submit" class="btn btn-primary save_app print">
+            Save & Print Form
           </button>
+          {% if print_invoice %}
+          <button type="submit" class="btn btn-primary save_app print_invoice">
+            Save & Print Invoice
+          </button>
+          {% endif %}
           {% if not app.checked_in %}
           <input type="hidden" class="complete" name="check_in" />
           <button type="submit" class="btn btn-success save_app action">Save & Check-In</button>

--- a/art_show/templates/print_macros.html
+++ b/art_show/templates/print_macros.html
@@ -113,7 +113,7 @@
   <label class="col-sm-3 control-label optional-field">Artist Signature</label>
   <div class="col-sm-6">
     <div class="form-control-static">
-      ____________________________________________________________
+      _________________________________________________________
     </div>
   </div>
 </div>
@@ -122,7 +122,7 @@
   <label class="col-sm-3 control-label optional-field">Date</label>
   <div class="col-sm-6">
     <div class="form-control-static">
-      ______________________________
+      ___________________________
     </div>
   </div>
 </div>
@@ -130,7 +130,7 @@
   <label class="col-sm-3 control-label optional-field">Convention Staff Signature</label>
   <div class="col-sm-6">
     <div class="form-control-static">
-      ____________________________________________________________
+      _________________________________________________________
     </div>
   </div>
 </div>
@@ -139,7 +139,7 @@
   <label class="col-sm-3 control-label optional-field">Date</label>
   <div class="col-sm-6">
     <div class="form-control-static">
-      ______________________________
+      ___________________________
     </div>
   </div>
 </div>


### PR DESCRIPTION
For some reason the onsite computers aren't opening two windows to print the two forms. We're quickly splitting the function into two buttons so art show can print both forms.